### PR TITLE
Test coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ scala:
 jdk:
   - oraclejdk8
 script:
-  - sbt -Dtoken=$GITHUB4S_ACCESS_TOKEN test
+  - sbt -Dtoken=$GITHUB4S_ACCESS_TOKEN clean coverage test
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/47deg/github4s.svg?branch=master)](https://travis-ci.org/47deg/github4s)
+[![codecov.io](http://codecov.io/github/47deg/github4s/coverage.svg?branch=master)](http://codecov.io/github/47deg/github4s?branch=master)
 
 Github4s
 =============

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 logLevel := Level.Warn
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")


### PR DESCRIPTION
This PR:
- Adds `sbt-scoverage` for generating test coverage reports.
- Add [Codecov.io](https://codecov.io/gh/47deg/github4s) in order to integrate the report in GitHub.

@FPerezP @fedefernandez @javipacheco Could you take a look please? Thank you