### PR TITLE
Upgrade cats and circe dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,12 @@ lazy val buildSettings = Seq(
 )
 
 lazy val dependencies = libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats" % "0.4.0",
+  "org.typelevel" %% "cats" % "0.6.0",
   "org.scalaz" %% "scalaz-concurrent" % "7.1.4",
   "org.scalaj" %% "scalaj-http" % "2.2.1",
-  "io.circe" %% "circe-core" % "0.3.0",
-  "io.circe" %% "circe-generic" % "0.3.0",
-  "io.circe" %% "circe-parser" % "0.3.0",
+  "io.circe" %% "circe-core" % "0.5.0-M1",
+  "io.circe" %% "circe-generic" % "0.5.0-M1",
+  "io.circe" %% "circe-parser" % "0.5.0-M1",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test",
   "com.ironcorelabs" %% "cats-scalatest" % "1.1.2" % "test"
 )


### PR DESCRIPTION
@rafaparadela can you publish a SNAPSHOT release with these changes? We can wait until circe hits 0.5.0 for a new release.Thanks in advance!