### PR TITLE
Add method to create gists

### DIFF
--- a/src/main/scala/github4s/Decoders.scala
+++ b/src/main/scala/github4s/Decoders.scala
@@ -171,4 +171,20 @@ object Decoders {
     )
   }
 
+  implicit val decodeGist: Decoder[Gist] = Decoder.instance { c ⇒
+    for {
+      url ← c.downField("url").as[String]
+      id ← c.downField("id").as[String]
+      description ← c.downField("description").as[String]
+      public ← c.downField("public").as[Boolean]
+      owner ← c.downField("owner").as[User]
+    } yield Gist(
+      url         = url,
+      id          = id,
+      description = description,
+      public      = public,
+      owner       = owner
+    )
+  }
+
 }

--- a/src/main/scala/github4s/Decoders.scala
+++ b/src/main/scala/github4s/Decoders.scala
@@ -177,13 +177,11 @@ object Decoders {
       id ← c.downField("id").as[String]
       description ← c.downField("description").as[String]
       public ← c.downField("public").as[Boolean]
-      owner ← c.downField("owner").as[User]
     } yield Gist(
       url         = url,
       id          = id,
       description = description,
-      public      = public,
-      owner       = owner
+      public      = public
     )
   }
 

--- a/src/main/scala/github4s/Github.scala
+++ b/src/main/scala/github4s/Github.scala
@@ -15,6 +15,7 @@ class Github(accessToken: Option[String] = None) {
   lazy val users = new GHUsers(accessToken)
   lazy val repos = new GHRepos(accessToken)
   lazy val auth = new GHAuth(accessToken)
+  lazy val gists = new GHGists(accessToken)
 
 }
 

--- a/src/main/scala/github4s/GithubAPIs.scala
+++ b/src/main/scala/github4s/GithubAPIs.scala
@@ -1,8 +1,8 @@
 package github4s
 
-import github4s.GithubResponses.{ GHResponse, GHIO }
+import github4s.GithubResponses.{ GHIO, GHResponse }
 import github4s.app._
-import github4s.free.algebra.{ AuthOps, RepositoryOps, UserOps }
+import github4s.free.algebra.{ AuthOps, GistOps, RepositoryOps, UserOps }
 import github4s.free.domain._
 
 class GHUsers(accessToken: Option[String] = None)(implicit O: UserOps[GitHub4s]) {
@@ -67,4 +67,14 @@ class GHAuth(accessToken: Option[String] = None)(implicit O: AuthOps[GitHub4s]) 
     state: String
   ): GHIO[GHResponse[OAuthToken]] =
     O.getAccessToken(client_id, client_secret, code, redirect_uri, state)
+}
+
+class GHGists(accessToken: Option[String] = None)(implicit O: GistOps[GitHub4s]) {
+  def newGist(
+    description: String,
+    public: Boolean,
+    files: Map[String, GistFile],
+    accessToken: Option[String]
+  ): GHIO[GHResponse[Gist]] =
+    O.newGist(description, public, files, accessToken)
 }

--- a/src/main/scala/github4s/GithubAPIs.scala
+++ b/src/main/scala/github4s/GithubAPIs.scala
@@ -73,8 +73,7 @@ class GHGists(accessToken: Option[String] = None)(implicit O: GistOps[GitHub4s])
   def newGist(
     description: String,
     public: Boolean,
-    files: Map[String, GistFile],
-    accessToken: Option[String]
+    files: Map[String, GistFile]
   ): GHIO[GHResponse[Gist]] =
     O.newGist(description, public, files, accessToken)
 }

--- a/src/main/scala/github4s/api/Gists.scala
+++ b/src/main/scala/github4s/api/Gists.scala
@@ -26,4 +26,5 @@ class Gists(implicit urls: GithubApiUrls) {
       "gists",
       data = NewGistRequest(description, public, files).asJson.noSpaces
     )
+
 }

--- a/src/main/scala/github4s/api/Gists.scala
+++ b/src/main/scala/github4s/api/Gists.scala
@@ -1,0 +1,29 @@
+package github4s.api
+
+import github4s.free.domain._
+import github4s.{ Decoders, GithubApiUrls, HttpClient }
+import io.circe.generic.auto._
+import io.circe.syntax._
+import cats.implicits._
+
+/** Factory to encapsulate calls related to Repositories operations  */
+class Gists(implicit urls: GithubApiUrls) {
+  import Decoders._
+
+  val httpClient = new HttpClient
+
+  /**
+    * Create a new gist
+    *
+    * @param description of the gist
+    * @param public boolean value that describes if the Gist should be public or not
+    * @param files map describing the filenames of the Gist and its contents
+    * @param accessToken to identify the authenticated user
+    */
+  def newGist(description: String, public: Boolean, files: Map[String, GistFile], accessToken: Option[String] = None) =
+    httpClient.post[Gist](
+      accessToken,
+      "gists",
+      data = NewGistRequest(description, public, files).asJson.noSpaces
+    )
+}

--- a/src/main/scala/github4s/app.scala
+++ b/src/main/scala/github4s/app.scala
@@ -5,5 +5,6 @@ import github4s.free.algebra._
 
 object app {
   type COGH01[A] = Coproduct[RepositoryOp, UserOp, A]
-  type GitHub4s[A] = Coproduct[AuthOp, COGH01, A]
+  type COGH02[A] = Coproduct[GistOp, COGH01, A]
+  type GitHub4s[A] = Coproduct[AuthOp, COGH02, A]
 }

--- a/src/main/scala/github4s/free/algebra/GistOps.scala
+++ b/src/main/scala/github4s/free/algebra/GistOps.scala
@@ -1,0 +1,42 @@
+package github4s.free.algebra
+
+import cats.free.{ Free, Inject }
+import github4s.GithubResponses._
+import github4s.free.domain.{ Gist, GistFile }
+
+/**
+  * Gist ops ADT
+  */
+sealed trait GistOp[A]
+
+final case class NewGist(
+  description: String,
+  public: Boolean,
+  files: Map[String, GistFile],
+  accessToken: Option[String] = None
+) extends GistOp[GHResponse[Gist]]
+
+/**
+  * Exposes Gists operations as a Free monadic algebra that may be combined with other Algebras via
+  * Coproduct
+  */
+
+class GistOps[F[_]](implicit I: Inject[GistOp, F]) {
+  def newGist(
+    description: String,
+    public: Boolean,
+    files: Map[String, GistFile],
+    accessToken: Option[String] = None
+  ): Free[F, GHResponse[Gist]] =
+    Free.inject[GistOp, F](NewGist(description, public, files))
+}
+
+/**
+  * Default implicit based DI factory from which instances of the GistOps may be obtained
+  */
+
+object GistOps {
+
+  implicit def instance[F[_]](implicit I: Inject[GistOp, F]): GistOps[F] = new GistOps[F]
+
+}

--- a/src/main/scala/github4s/free/algebra/GistOps.scala
+++ b/src/main/scala/github4s/free/algebra/GistOps.scala
@@ -27,8 +27,7 @@ class GistOps[F[_]](implicit I: Inject[GistOp, F]) {
     public: Boolean,
     files: Map[String, GistFile],
     accessToken: Option[String] = None
-  ): Free[F, GHResponse[Gist]] =
-    Free.inject[GistOp, F](NewGist(description, public, files))
+  ): Free[F, GHResponse[Gist]] = Free.inject[GistOp, F](NewGist(description, public, files, accessToken))
 }
 
 /**

--- a/src/main/scala/github4s/free/domain/Gist.scala
+++ b/src/main/scala/github4s/free/domain/Gist.scala
@@ -1,0 +1,19 @@
+package github4s.free.domain
+
+case class Gist(
+  url: String,
+  id: String,
+  description: String,
+  public: Boolean,
+  owner: User
+)
+
+case class GistFile(
+  content: String
+)
+
+case class NewGistRequest(
+  description: String,
+  public: Boolean,
+  files: Map[String, GistFile]
+)

--- a/src/main/scala/github4s/free/domain/Gist.scala
+++ b/src/main/scala/github4s/free/domain/Gist.scala
@@ -4,8 +4,7 @@ case class Gist(
   url: String,
   id: String,
   description: String,
-  public: Boolean,
-  owner: User
+  public: Boolean
 )
 
 case class GistFile(

--- a/src/main/scala/github4s/free/interpreters/Interpreters.scala
+++ b/src/main/scala/github4s/free/interpreters/Interpreters.scala
@@ -1,13 +1,12 @@
 package github4s.free.interpreters
 
 import cats.implicits._
-import cats.{ MonadError, ApplicativeError, ~>, Eval }
+import cats.{ ApplicativeError, Eval, MonadError, ~> }
 import github4s.GithubDefaultUrls._
-import github4s.api.{ Users, Auth, Repos }
+import github4s.api.{ Auth, Gists, Repos, Users }
 import github4s.app.{ COGH01, GitHub4s }
 import github4s.free.algebra._
 import io.circe.Decoder
-
 import simulacrum.typeclass
 
 @typeclass trait Capture[M[_]] {
@@ -65,6 +64,18 @@ trait Interpreters {
       case NewAuth(username, password, scopes, note, client_id, client_secret) ⇒ C.capture(auth.newAuth(username, password, scopes, note, client_id, client_secret))
       case AuthorizeUrl(client_id, redirect_uri, scopes) ⇒ C.capture(auth.authorizeUrl(client_id, redirect_uri, scopes))
       case GetAccessToken(client_id, client_secret, code, redirect_uri, state) ⇒ C.capture(auth.getAccessToken(client_id, client_secret, code, redirect_uri, state))
+    }
+  }
+
+  /**
+    * Lifts Gist Ops to an effect capturing Monad such as Task via natural transformations
+    */
+  def gistOpsInterpreter[M[_]](implicit A: ApplicativeError[M, Throwable], C: Capture[M]): GistOp ~> M = new (GistOp ~> M) {
+
+    val gists = new Gists()
+
+    def apply[A](fa: GistOp[A]): M[A] = fa match {
+      case NewGist(description, public, files, accessToken) ⇒ C.capture(gists.newGist(description, public, files, accessToken))
     }
   }
 

--- a/src/main/scala/github4s/free/interpreters/Interpreters.scala
+++ b/src/main/scala/github4s/free/interpreters/Interpreters.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import cats.{ ApplicativeError, Eval, MonadError, ~> }
 import github4s.GithubDefaultUrls._
 import github4s.api.{ Auth, Gists, Repos, Users }
-import github4s.app.{ COGH01, GitHub4s }
+import github4s.app.{ COGH01, COGH02, GitHub4s }
 import github4s.free.algebra._
 import io.circe.Decoder
 import simulacrum.typeclass
@@ -21,7 +21,8 @@ trait Interpreters {
     C: Capture[M]
   ): GitHub4s ~> M = {
     val c01interpreter: COGH01 ~> M = repositoryOpsInterpreter[M] or userOpsInterpreter[M]
-    val all: GitHub4s ~> M = authOpsInterpreter[M] or c01interpreter
+    val c02interpreter: COGH02 ~> M = gistOpsInterpreter[M] or c01interpreter
+    val all: GitHub4s ~> M = authOpsInterpreter[M] or c02interpreter
     all
   }
 

--- a/src/test/scala/github4s/integration/GHGistsSpec.scala
+++ b/src/test/scala/github4s/integration/GHGistsSpec.scala
@@ -12,7 +12,7 @@ class GHGistsSpec extends FlatSpec with Matchers with TestUtils {
   "Gists >> Post" should "return the provided gist" in {
     val response = Github(accessToken)
       .gists
-      .newGist(validGistDescription, validGistPublic, validGistFiles, accessToken)
+      .newGist(validGistDescription, validGistPublic, validGistFiles)
       .exec[Id]
     response should be('right)
     response.toOption map { r ⇒

--- a/src/test/scala/github4s/integration/GHGistsSpec.scala
+++ b/src/test/scala/github4s/integration/GHGistsSpec.scala
@@ -1,0 +1,23 @@
+package github4s.integration
+
+import cats.Id
+import cats.implicits._
+import github4s.Github._
+import github4s.implicits._
+import github4s.Github
+import github4s.utils.TestUtils
+import org.scalatest._
+
+class GHGistsSpec extends FlatSpec with Matchers with TestUtils {
+  "Gists >> Post" should "return the provided gist" in {
+    val response = Github(accessToken)
+      .gists
+      .newGist(validGistDescription, validGistPublic, validGistFiles, accessToken)
+      .exec[Id]
+    response should be('right)
+    response.toOption map { r ⇒
+      r.result.description shouldBe validGistDescription
+      r.statusCode shouldBe createdStatusCode
+    }
+  }
+}

--- a/src/test/scala/github4s/unit/ApiSpec.scala
+++ b/src/test/scala/github4s/unit/ApiSpec.scala
@@ -222,7 +222,6 @@ class ApiSpec
   }
 
   "Gists >> PostGist" should "return the provided gist for a valid request" in {
-    println(s"******* Token: $accessToken")
     val response = gists.newGist(validGistDescription, validGistPublic, validGistFiles, accessToken)
     response should be('right)
 

--- a/src/test/scala/github4s/unit/ApiSpec.scala
+++ b/src/test/scala/github4s/unit/ApiSpec.scala
@@ -1,6 +1,6 @@
 package github4s.unit
 
-import github4s.api.{ Users, Repos, Auth }
+import github4s.api.{ Auth, Gists, Repos, Users }
 import github4s.free.domain.Pagination
 import github4s.utils.{ DummyGithubUrls, MockGithubApiServer, TestUtils }
 import org.scalatest._
@@ -16,6 +16,7 @@ class ApiSpec
   val auth = new Auth
   val repos = new Repos
   val users = new Users
+  val gists = new Gists
 
   "Auth >> NewAuth" should "return a valid token when valid credential is provided" in {
     val response = auth.newAuth(validUsername, "", validScopes, validNote, validClientId, "")
@@ -216,6 +217,17 @@ class ApiSpec
     response.toOption map { r ⇒
       r.result.isEmpty shouldBe true
       r.statusCode shouldBe okStatusCode
+    }
+
+  }
+
+  "Gists >> PostGist" should "return the provided gist for a valid request" in {
+    println(s"******* Token: $accessToken")
+    val response = gists.newGist(validGistDescription, validGistPublic, validGistFiles, accessToken)
+    response should be('right)
+
+    response.toOption map { r ⇒
+      r.statusCode shouldBe createdStatusCode
     }
 
   }

--- a/src/test/scala/github4s/utils/FakeResponses.scala
+++ b/src/test/scala/github4s/utils/FakeResponses.scala
@@ -441,4 +441,85 @@ trait FakeResponses {
       |}
     """.stripMargin
 
+  val newGistValidResponse =
+    """
+      |{
+      |  "url": "https://api.github.com/gists/aa5a315d61ae9438b18d",
+      |  "forks_url": "https://api.github.com/gists/aa5a315d61ae9438b18d/forks",
+      |  "commits_url": "https://api.github.com/gists/aa5a315d61ae9438b18d/commits",
+      |  "id": "aa5a315d61ae9438b18d",
+      |  "description": "description of gist",
+      |  "public": true,
+      |  "owner": {
+      |    "login": "rafaparadela",
+      |    "id": 1,
+      |    "avatar_url": "hhttps://avatars.githubusercontent.com/u/315070?v=3",
+      |    "gravatar_id": "",
+      |    "url": "https://api.github.com/users/rafaparadela",
+      |    "html_url": "https://github.com/rafaparadela",
+      |    "followers_url": "https://api.github.com/users/rafaparadela/followers",
+      |    "following_url": "https://api.github.com/users/rafaparadela/following{/other_user}",
+      |    "gists_url": "https://api.github.com/users/rafaparadela/gists{/gist_id}",
+      |    "starred_url": "https://api.github.com/users/rafaparadela/starred{/owner}{/repo}",
+      |    "subscriptions_url": "https://api.github.com/users/rafaparadela/subscriptions",
+      |    "organizations_url": "https://api.github.com/users/rafaparadela/orgs",
+      |    "repos_url": "https://api.github.com/users/rafaparadela/repos",
+      |    "events_url": "https://api.github.com/users/rafaparadela/events{/privacy}",
+      |    "received_events_url": "https://api.github.com/users/rafaparadela/received_events",
+      |    "type": "User",
+      |    "site_admin": false
+      |  },
+      |  "user": null,
+      |  "files": {
+      |    "ring.erl": {
+      |      "size": 932,
+      |      "raw_url": "https://gist.githubusercontent.com/raw/365370/8c4d2d43d178df44f4c03a7f2ac0ff512853564e/ring.erl",
+      |      "type": "text/plain",
+      |      "language": "Erlang",
+      |      "truncated": false,
+      |      "content": "contents of gist"
+      |    }
+      |  },
+      |  "truncated": false,
+      |  "comments": 0,
+      |  "comments_url": "https://api.github.com/gists/aa5a315d61ae9438b18d/comments/",
+      |  "html_url": "https://gist.github.com/aa5a315d61ae9438b18d",
+      |  "git_pull_url": "https://gist.github.com/aa5a315d61ae9438b18d.git",
+      |  "git_push_url": "https://gist.github.com/aa5a315d61ae9438b18d.git",
+      |  "created_at": "2010-04-14T02:15:15Z",
+      |  "updated_at": "2011-06-20T11:34:15Z",
+      |  "forks": [],
+      |  "history": [
+      |    {
+      |      "url": "https://api.github.com/gists/aa5a315d61ae9438b18d/57a7f021a713b1c5a6a199b54cc514735d2d462f",
+      |      "version": "57a7f021a713b1c5a6a199b54cc514735d2d462f",
+      |      "user": {
+      |        "login": "rafaparadela",
+      |        "id": 1,
+      |        "avatar_url": "hhttps://avatars.githubusercontent.com/u/315070?v=3",
+      |        "gravatar_id": "",
+      |        "url": "https://api.github.com/users/rafaparadela",
+      |        "html_url": "https://github.com/rafaparadela",
+      |        "followers_url": "https://api.github.com/users/rafaparadela/followers",
+      |        "following_url": "https://api.github.com/users/rafaparadela/following{/other_user}",
+      |        "gists_url": "https://api.github.com/users/rafaparadela/gists{/gist_id}",
+      |        "starred_url": "https://api.github.com/users/rafaparadela/starred{/owner}{/repo}",
+      |        "subscriptions_url": "https://api.github.com/users/rafaparadela/subscriptions",
+      |        "organizations_url": "https://api.github.com/users/rafaparadela/orgs",
+      |        "repos_url": "https://api.github.com/users/rafaparadela/repos",
+      |        "events_url": "https://api.github.com/users/rafaparadela/events{/privacy}",
+      |        "received_events_url": "https://api.github.com/users/rafaparadela/received_events",
+      |        "type": "User",
+      |        "site_admin": false
+      |      },
+      |      "change_status": {
+      |        "deletions": 0,
+      |        "additions": 180,
+      |        "total": 180
+      |      },
+      |      "committed_at": "2010-04-14T02:15:15Z"
+      |    }
+      |  ]
+      |}
+    """.stripMargin
 }

--- a/src/test/scala/github4s/utils/MockGithubApiServer.scala
+++ b/src/test/scala/github4s/utils/MockGithubApiServer.scala
@@ -82,4 +82,12 @@ trait MockGithubApiServer extends MockServerService with FakeResponses with Test
   mockServer.when(request.withMethod("GET").withPath(s"/repos/$validRepoOwner/$invalidRepoName/contributors"))
     .respond(response.withStatusCode(notFoundStatusCode).withBody(notFoundResponse))
 
+  //Gists >> post new gist
+
+  mockServer.when(request.withMethod("POST").withPath(s"/gists").withHeader("Authorization", tokenHeader))
+    .respond(response.withStatusCode(createdStatusCode).withBody(newGistValidResponse))
+
+  mockServer.when(request.withMethod("POST").withPath(s"/gists").withHeader(not("Authorization")))
+    .respond(response.withStatusCode(unauthorizedStatusCode).withBody(unauthorizedReponse))
+
 }

--- a/src/test/scala/github4s/utils/TestUtils.scala
+++ b/src/test/scala/github4s/utils/TestUtils.scala
@@ -1,5 +1,7 @@
 package github4s.utils
 
+import github4s.free.domain.GistFile
+
 import scalaj.http.HttpConstants._
 
 trait TestUtils {
@@ -33,9 +35,15 @@ trait TestUtils {
   val invalidSinceInt = 999999999
 
   val okStatusCode = 200
+  val createdStatusCode = 201
   val unauthorizedStatusCode = 401
   val notFoundStatusCode = 404
 
   val validAnonParameter = "true"
   val invalidAnonParameter = "X"
+
+  val validGistDescription = "A Gist"
+  val validGistPublic = true
+  val validGistFile = GistFile("val meaningOfLife = 42")
+  val validGistFiles = Map("file1.scala" → validGistFile)
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.0-SNAPSHOT"
+version in ThisBuild := "0.8.1-SNAPSHOT"


### PR DESCRIPTION
This PR includes code that allows users of Github4s to create gists (either anonymous or associated with a user - given an access token with the scope "gist"). Could you please review, @juanpedromoreno? Thanks!