### PR TITLE
Adding custom user headers at exec time

### DIFF
--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -31,7 +31,7 @@ WIP: Every Github4s api returns a `Free[GHResponse[A], A]` where `GHResponse[A]`
 case class GHResult[A](result: A, statusCode: Int, headers: Map[String, IndexedSeq[String]])
 ```
 
-For getting an user
+To get an user
 
 ```tut:silent
 val user1 = Github(accessToken).users.get("rafaparadela")
@@ -45,7 +45,7 @@ import github4s.Github._
 import scalaj.http._
 
 object ProgramEval {
-    val u1 = user1.exec[Eval, HttpResponse[String]].value
+    val u1 = user1.exec[Eval, HttpResponse[String]]().value
 }
 
 ```
@@ -71,7 +71,7 @@ import cats.Id
 import scalaj.http._
 
 object ProgramId {
-    val u2 = Github(accessToken).users.get("raulraja").exec[Id, HttpResponse[String]]
+    val u2 = Github(accessToken).users.get("raulraja").exec[Id, HttpResponse[String]]()
 }
 ```
 
@@ -86,7 +86,8 @@ import scala.concurrent.Await
 import scalaj.http._
 
 object ProgramFuture {
-    val u3 = Github(accessToken).users.get("dialelo").exec[Future, HttpResponse[String]]
+    // execFuture[C] is a convenience access to exec[Future, C]
+    val u3 = Github(accessToken).users.get("dialelo").execFuture[HttpResponse[String]]()
     Await.result(u3, 2.seconds)
 }
 ```
@@ -100,7 +101,7 @@ import scalaj.http._
 import github4s.jvm.Implicits._
 
 object ProgramTask {
-    val u4 = Github(accessToken).users.get("franciscodr").exec[Task, HttpResponse[String]]
+    val u4 = Github(accessToken).users.get("franciscodr").exec[Task, HttpResponse[String]]()
     u4.attemptRun
 }
 ```
@@ -120,7 +121,9 @@ val accessToken = sys.props.get("token")
 
 ```tut:book
 object ProgramEval {
-    val user1 = Github(accessToken).users.get("rafaparadela").exec[Eval, HttpResponse[String]].value
+    // exec methods let users to include optional headers for any GitHub API request:
+    val userHeaders = Map("user-agent" -> "github4s")
+    val user1 = Github(accessToken).users.get("rafaparadela").exec[Eval, HttpResponse[String]](userHeaders).value
 }
 
 ProgramEval.user1 should be ('right)

--- a/github4s/js/src/test/scala/github4s/utils/integration/GHAuthSpec.scala
+++ b/github4s/js/src/test/scala/github4s/utils/integration/GHAuthSpec.scala
@@ -43,7 +43,7 @@ class GHAuthSpec extends AsyncFlatSpec with Matchers with TestUtils {
                validNote,
                validClientId,
                invalidClientSecret)
-      .exec[Future, SimpleHttpResponse]
+      .execFuture(headerUserAgent)
 
     testFutureIsLeft(response)
   }
@@ -52,7 +52,7 @@ class GHAuthSpec extends AsyncFlatSpec with Matchers with TestUtils {
     val response =
       Github().auth
         .authorizeUrl(validClientId, validRedirectUri, validScopes)
-        .exec[Future, SimpleHttpResponse]
+        .execFuture(headerUserAgent)
 
     testFutureIsRight[Authorize](response, { r =>
       r.result.url.contains(validRedirectUri) shouldBe true
@@ -63,7 +63,7 @@ class GHAuthSpec extends AsyncFlatSpec with Matchers with TestUtils {
   "Auth >> GetAccessToken" should "return error on Left for invalid code value" in {
     val response = Github().auth
       .getAccessToken(validClientId, invalidClientSecret, "", validRedirectUri, "")
-      .exec[Future, SimpleHttpResponse]
+      .execFuture(headerUserAgent)
 
     testFutureIsLeft(response)
   }

--- a/github4s/js/src/test/scala/github4s/utils/integration/GHGistsSpec.scala
+++ b/github4s/js/src/test/scala/github4s/utils/integration/GHGistsSpec.scala
@@ -39,7 +39,7 @@ class GHGistsSpec extends AsyncFlatSpec with Matchers with TestUtils {
       .newGist(validGistDescription,
                validGistPublic,
                Map(validGistFilename -> GistFile(validGistFileContent)))
-      .exec[Future, SimpleHttpResponse]
+      .execFuture(headerUserAgent)
 
     testFutureIsRight[Gist](response, { r =>
       r.result.description shouldBe validGistDescription

--- a/github4s/js/src/test/scala/github4s/utils/integration/GHReposSpec.scala
+++ b/github4s/js/src/test/scala/github4s/utils/integration/GHReposSpec.scala
@@ -38,7 +38,7 @@ class GHReposSpec extends AsyncFlatSpec with Matchers with TestUtils {
   "Repos >> Get" should "return the expected name when valid repo is provided" in {
 
     val response =
-      Github(accessToken).repos.get(validRepoOwner, validRepoName).exec[Future, SimpleHttpResponse]
+      Github(accessToken).repos.get(validRepoOwner, validRepoName).execFuture(headerUserAgent)
 
     testFutureIsRight[Repository](response, { r =>
       r.result.name shouldBe validRepoName
@@ -48,9 +48,7 @@ class GHReposSpec extends AsyncFlatSpec with Matchers with TestUtils {
 
   it should "return error when an invalid repo name is passed" in {
     val response =
-      Github(accessToken).repos
-        .get(validRepoOwner, invalidRepoName)
-        .exec[Future, SimpleHttpResponse]
+      Github(accessToken).repos.get(validRepoOwner, invalidRepoName).execFuture(headerUserAgent)
 
     testFutureIsLeft(response)
   }
@@ -59,7 +57,7 @@ class GHReposSpec extends AsyncFlatSpec with Matchers with TestUtils {
     val response =
       Github(accessToken).repos
         .listCommits(validRepoOwner, validRepoName)
-        .exec[Future, SimpleHttpResponse]
+        .execFuture(headerUserAgent)
 
     testFutureIsRight[List[Commit]](response, { r =>
       r.result.nonEmpty shouldBe true
@@ -71,7 +69,7 @@ class GHReposSpec extends AsyncFlatSpec with Matchers with TestUtils {
     val response =
       Github(accessToken).repos
         .listCommits(invalidRepoName, validRepoName)
-        .exec[Future, SimpleHttpResponse]
+        .execFuture(headerUserAgent)
 
     testFutureIsLeft(response)
   }
@@ -80,7 +78,7 @@ class GHReposSpec extends AsyncFlatSpec with Matchers with TestUtils {
     val response =
       Github(accessToken).repos
         .listContributors(validRepoOwner, validRepoName)
-        .exec[Future, SimpleHttpResponse]
+        .execFuture(headerUserAgent)
 
     testFutureIsRight[List[User]](response, { r =>
       r.result shouldNot be(empty)
@@ -92,7 +90,7 @@ class GHReposSpec extends AsyncFlatSpec with Matchers with TestUtils {
     val response =
       Github(accessToken).repos
         .listContributors(invalidRepoName, validRepoName)
-        .exec[Future, SimpleHttpResponse]
+        .execFuture(headerUserAgent)
 
     testFutureIsLeft(response)
   }

--- a/github4s/js/src/test/scala/github4s/utils/integration/GHUsersSpec.scala
+++ b/github4s/js/src/test/scala/github4s/utils/integration/GHUsersSpec.scala
@@ -35,7 +35,7 @@ class GHUsersSpec extends AsyncFlatSpec with Matchers with TestUtils {
   override implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   "Users >> Get" should "return the expected login for a valid username" in {
-    val response = Github(accessToken).users.get(validUsername).exec[Future, SimpleHttpResponse]
+    val response = Github(accessToken).users.get(validUsername).execFuture(headerUserAgent)
 
     testFutureIsRight[User](response, { r =>
       r.result.login shouldBe validUsername
@@ -44,18 +44,20 @@ class GHUsersSpec extends AsyncFlatSpec with Matchers with TestUtils {
   }
 
   it should "return error on Left for invalid username" in {
-    val response = Github(accessToken).users.get(invalidUsername).exec[Future, SimpleHttpResponse]
+    val response = Github(accessToken).users.get(invalidUsername).execFuture(headerUserAgent)
+
     testFutureIsLeft(response)
   }
 
   "Users >> GetAuth" should "return error on Left when no accessToken is provided" in {
-    val response = Github().users.getAuth.exec[Future, SimpleHttpResponse]
+    val response = Github().users.getAuth.exec[Future, SimpleHttpResponse](headerUserAgent)
+
     testFutureIsLeft(response)
   }
 
   "Users >> GetUsers" should "return users for a valid since value" in {
     val response =
-      Github(accessToken).users.getUsers(validSinceInt).exec[Future, SimpleHttpResponse]
+      Github(accessToken).users.getUsers(validSinceInt).execFuture(headerUserAgent)
 
     testFutureIsRight[List[User]](response, { r =>
       r.result.nonEmpty shouldBe true
@@ -65,7 +67,7 @@ class GHUsersSpec extends AsyncFlatSpec with Matchers with TestUtils {
 
   it should "return an empty list when a invalid since value is provided" in {
     val response =
-      Github(accessToken).users.getUsers(invalidSinceInt).exec[Future, SimpleHttpResponse]
+      Github(accessToken).users.getUsers(invalidSinceInt).execFuture(headerUserAgent)
 
     testFutureIsRight[List[User]](response, { r =>
       r.result.isEmpty shouldBe true

--- a/github4s/js/src/test/scala/github4s/utils/utils/TestUtils.scala
+++ b/github4s/js/src/test/scala/github4s/utils/utils/TestUtils.scala
@@ -51,8 +51,9 @@ trait TestUtils extends Matchers {
     }
   }
 
-  val accessToken = Option(github4s.BuildInfo.token)
-  def tokenHeader = "token " + accessToken.getOrElse("")
+  val accessToken     = Option(github4s.BuildInfo.token)
+  def tokenHeader     = "token " + accessToken.getOrElse("")
+  val headerUserAgent = Map("user-agent" -> "github4s")
 
   val validUsername   = "rafaparadela"
   val invalidUsername = "GHInvalidaUserName"

--- a/github4s/jvm/src/test/scala/github4s/integration/GHAuthSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/integration/GHAuthSpec.scala
@@ -40,7 +40,8 @@ class GHAuthSpec extends FlatSpec with Matchers with TestUtils {
                validNote,
                validClientId,
                invalidClientSecret)
-      .exec[Id, HttpResponse[String]]
+      .exec[Id, HttpResponse[String]](headerUserAgent)
+
     response should be('left)
   }
 
@@ -48,7 +49,8 @@ class GHAuthSpec extends FlatSpec with Matchers with TestUtils {
     val response =
       Github().auth
         .authorizeUrl(validClientId, validRedirectUri, validScopes)
-        .exec[Id, HttpResponse[String]]
+        .exec[Id, HttpResponse[String]](headerUserAgent)
+
     response should be('right)
 
     response.toOption map { r ⇒
@@ -61,7 +63,7 @@ class GHAuthSpec extends FlatSpec with Matchers with TestUtils {
   "Auth >> GetAccessToken" should "return error on Left for invalid code value" in {
     val response = Github().auth
       .getAccessToken(validClientId, invalidClientSecret, "", validRedirectUri, "")
-      .exec[Id, HttpResponse[String]]
+      .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('left)
   }
 

--- a/github4s/jvm/src/test/scala/github4s/integration/GHGistsSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/integration/GHGistsSpec.scala
@@ -38,7 +38,8 @@ class GHGistsSpec extends FlatSpec with Matchers with TestUtils {
       .newGist(validGistDescription,
                validGistPublic,
                Map(validGistFilename -> GistFile(validGistFileContent)))
-      .exec[Id, HttpResponse[String]]
+      .exec[Id, HttpResponse[String]](headerUserAgent)
+
     response should be('right)
     response.toOption map { r ⇒
       r.result.description shouldBe validGistDescription

--- a/github4s/jvm/src/test/scala/github4s/integration/GHReposSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/integration/GHReposSpec.scala
@@ -37,7 +37,9 @@ class GHReposSpec extends FlatSpec with Matchers with TestUtils {
   "Repos >> Get" should "return the expected name when valid repo is provided" in {
 
     val response =
-      Github(accessToken).repos.get(validRepoOwner, validRepoName).exec[Id, HttpResponse[String]]
+      Github(accessToken).repos
+        .get(validRepoOwner, validRepoName)
+        .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('right)
     response.toOption map { r ⇒
       r.result.name shouldBe validRepoName
@@ -47,14 +49,16 @@ class GHReposSpec extends FlatSpec with Matchers with TestUtils {
 
   it should "return error when an invalid repo name is passed" in {
     val response =
-      Github(accessToken).repos.get(validRepoOwner, invalidRepoName).exec[Id, HttpResponse[String]]
+      Github(accessToken).repos
+        .get(validRepoOwner, invalidRepoName)
+        .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('left)
   }
 
   "Repos >> ListCommits" should "return the expected list of commits for valid data" in {
     val response = Github(accessToken).repos
       .listCommits(validRepoOwner, validRepoName)
-      .exec[Id, HttpResponse[String]]
+      .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -66,7 +70,7 @@ class GHReposSpec extends FlatSpec with Matchers with TestUtils {
   it should "return error for invalid repo name" in {
     val response = Github(accessToken).repos
       .listCommits(invalidRepoName, validRepoName)
-      .exec[Id, HttpResponse[String]]
+      .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('left)
   }
 
@@ -74,7 +78,7 @@ class GHReposSpec extends FlatSpec with Matchers with TestUtils {
     val response =
       Github(accessToken).repos
         .listContributors(validRepoOwner, validRepoName)
-        .exec[Id, HttpResponse[String]]
+        .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -88,7 +92,7 @@ class GHReposSpec extends FlatSpec with Matchers with TestUtils {
     val response =
       Github(accessToken).repos
         .listContributors(invalidRepoName, validRepoName)
-        .exec[Id, HttpResponse[String]]
+        .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('left)
   }
 

--- a/github4s/jvm/src/test/scala/github4s/integration/GHUsersSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/integration/GHUsersSpec.scala
@@ -34,7 +34,9 @@ import scalaj.http.HttpResponse
 class GHUsersSpec extends FlatSpec with Matchers with TestUtils {
 
   "Users >> Get" should "return the expected login for a valid username" in {
-    val response = Github(accessToken).users.get(validUsername).exec[Id, HttpResponse[String]]
+    val response =
+      Github(accessToken).users.get(validUsername).exec[Id, HttpResponse[String]](headerUserAgent)
+
     response should be('right)
     response.toOption map { r ⇒
       r.result.login shouldBe validUsername
@@ -43,17 +45,22 @@ class GHUsersSpec extends FlatSpec with Matchers with TestUtils {
   }
 
   it should "return error on Left for invalid username" in {
-    val response = Github(accessToken).users.get(invalidUsername).exec[Id, HttpResponse[String]]
+    val response = Github(accessToken).users
+      .get(invalidUsername)
+      .exec[Id, HttpResponse[String]](headerUserAgent)
+
     response should be('left)
   }
 
   "Users >> GetAuth" should "return error on Left when no accessToken is provided" in {
-    val response = Github().users.getAuth.exec[Id, HttpResponse[String]]
+    val response = Github().users.getAuth.exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('left)
   }
 
   "Users >> GetUsers" should "return users for a valid since value" in {
-    val response = Github(accessToken).users.getUsers(validSinceInt).exec[Id, HttpResponse[String]]
+    val response = Github(accessToken).users
+      .getUsers(validSinceInt)
+      .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -64,7 +71,9 @@ class GHUsersSpec extends FlatSpec with Matchers with TestUtils {
 
   it should "return an empty list when a invalid since value is provided" in {
     val response =
-      Github(accessToken).users.getUsers(invalidSinceInt).exec[Id, HttpResponse[String]]
+      Github(accessToken).users
+        .getUsers(invalidSinceInt)
+        .exec[Id, HttpResponse[String]](headerUserAgent)
     response should be('right)
 
     response.toOption map { r ⇒

--- a/github4s/jvm/src/test/scala/github4s/unit/ApiSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/unit/ApiSpec.scala
@@ -45,7 +45,13 @@ class ApiSpec
   val gists = new Gists[HttpResponse[String], Id]
 
   "Auth >> NewAuth" should "return a valid token when valid credential is provided" in {
-    val response = auth.newAuth(validUsername, "", validScopes, validNote, validClientId, "")
+    val response = auth.newAuth(validUsername,
+                                "",
+                                validScopes,
+                                validNote,
+                                validClientId,
+                                "",
+                                headers = headerUserAgent)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -56,7 +62,13 @@ class ApiSpec
 
   it should "return error on Left when invalid credential is provided" in {
     val response =
-      auth.newAuth(validUsername, invalidPassword, validScopes, validNote, validClientId, "")
+      auth.newAuth(validUsername,
+                   invalidPassword,
+                   validScopes,
+                   validNote,
+                   validClientId,
+                   "",
+                   headers = headerUserAgent)
     response should be('left)
   }
 
@@ -71,7 +83,7 @@ class ApiSpec
   }
 
   "Auth >> GetAccessToken" should "return a valid access_token when a valid code is provided" in {
-    val response = auth.getAccessToken("", "", validCode, "", "")
+    val response = auth.getAccessToken("", "", validCode, "", "", headers = headerUserAgent)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -82,13 +94,13 @@ class ApiSpec
   }
 
   it should "return error on Left when invalid code is provided" in {
-    val response = auth.getAccessToken("", "", invalidCode, "", "")
+    val response = auth.getAccessToken("", "", invalidCode, "", "", headers = headerUserAgent)
     response should be('left)
   }
 
   "Repos >> Get" should "return the expected name when valid repo is provided" in {
 
-    val response = repos.get(accessToken, validRepoOwner, validRepoName)
+    val response = repos.get(accessToken, headerUserAgent, validRepoOwner, validRepoName)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -99,13 +111,14 @@ class ApiSpec
   }
 
   it should "return error when an invalid repo name is passed" in {
-    val response = repos.get(accessToken, validRepoOwner, invalidRepoName)
+    val response = repos.get(accessToken, headerUserAgent, validRepoOwner, invalidRepoName)
     response should be('left)
   }
 
   "Repos >> ListCommits" should "return the expected list of commits for valid data" in {
     val response = repos.listCommits(
       accessToken = accessToken,
+      headers = headerUserAgent,
       owner = validRepoOwner,
       repo = validRepoName,
       pagination = Option(Pagination(validPage, validPerPage))
@@ -121,6 +134,7 @@ class ApiSpec
   it should "return an empty list of commits for invalid page parameter" in {
     val response = repos.listCommits(
       accessToken = accessToken,
+      headers = headerUserAgent,
       owner = validRepoOwner,
       repo = validRepoName,
       pagination = Option(Pagination(invalidPage, validPerPage))
@@ -136,13 +150,14 @@ class ApiSpec
   }
 
   it should "return error for invalid repo name" in {
-    val response = repos.listCommits(accessToken, validRepoOwner, invalidRepoName)
+    val response = repos.listCommits(accessToken, headerUserAgent, validRepoOwner, invalidRepoName)
     response should be('left)
   }
 
   "Repos >> ListContributors" should "return the expected list of contributors for valid data" in {
     val response = repos.listContributors(
       accessToken = accessToken,
+      headers = headerUserAgent,
       owner = validRepoOwner,
       repo = validRepoName
     )
@@ -159,6 +174,7 @@ class ApiSpec
   it should "return the expected list of contributors for valid data, including a valid anon parameter" in {
     val response = repos.listContributors(
       accessToken = accessToken,
+      headers = headerUserAgent,
       owner = validRepoOwner,
       repo = validRepoName,
       anon = Option(validAnonParameter)
@@ -175,6 +191,7 @@ class ApiSpec
   it should "return an empty list of contributors for invalid anon parameter" in {
     val response = repos.listContributors(
       accessToken = accessToken,
+      headers = headerUserAgent,
       owner = validRepoOwner,
       repo = validRepoName,
       anon = Some(invalidAnonParameter)
@@ -189,13 +206,14 @@ class ApiSpec
   }
 
   it should "return error for invalid repo name" in {
-    val response = repos.listContributors(accessToken, validRepoOwner, invalidRepoName)
+    val response =
+      repos.listContributors(accessToken, headerUserAgent, validRepoOwner, invalidRepoName)
     response should be('left)
   }
 
   "Users >> Get" should "return the expected login for a valid username" in {
 
-    val response = users.get(accessToken, validUsername)
+    val response = users.get(accessToken, headerUserAgent, validUsername)
 
     response should be('right)
     response.toOption map { r ⇒
@@ -206,12 +224,12 @@ class ApiSpec
   }
 
   it should "return error on Left for invalid username" in {
-    val response = users.get(accessToken, invalidUsername)
+    val response = users.get(accessToken, headerUserAgent, invalidUsername)
     response should be('left)
   }
 
   "Users >> GetAuth" should "return the expected login for a valid accessToken" in {
-    val response = users.getAuth(accessToken)
+    val response = users.getAuth(accessToken, headerUserAgent)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -222,12 +240,12 @@ class ApiSpec
   }
 
   it should "return error on Left when no accessToken is provided" in {
-    val response = users.getAuth(None)
+    val response = users.getAuth(None, headerUserAgent)
     response should be('left)
   }
 
   "Users >> GetUsers" should "return users for a valid since value" in {
-    val response = users.getUsers(accessToken, validSinceInt)
+    val response = users.getUsers(accessToken, headerUserAgent, validSinceInt)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -238,7 +256,7 @@ class ApiSpec
   }
 
   it should "return an empty list when a invalid since value is provided" in {
-    val response = users.getUsers(accessToken, invalidSinceInt)
+    val response = users.getUsers(accessToken, headerUserAgent, invalidSinceInt)
     response should be('right)
 
     response.toOption map { r ⇒
@@ -253,6 +271,7 @@ class ApiSpec
       gists.newGist(validGistDescription,
                     validGistPublic,
                     Map(validGistFilename -> GistFile(validGistFileContent)),
+                    headerUserAgent,
                     accessToken)
     response should be('right)
 

--- a/github4s/jvm/src/test/scala/github4s/utils/TestUtils.scala
+++ b/github4s/jvm/src/test/scala/github4s/utils/TestUtils.scala
@@ -25,8 +25,9 @@ import com.github.marklister.base64.Base64.Encoder
 
 trait TestUtils {
 
-  val accessToken = sys.props.get("token")
-  def tokenHeader = "token " + accessToken.getOrElse("")
+  val accessToken     = sys.props.get("token")
+  def tokenHeader     = "token " + accessToken.getOrElse("")
+  val headerUserAgent = Map("user-agent" -> "github4s")
 
   val validUsername   = "rafaparadela"
   val invalidUsername = "GHInvalidaUserName"

--- a/github4s/shared/src/main/scala/github4s/HttpClient.scala
+++ b/github4s/shared/src/main/scala/github4s/HttpClient.scala
@@ -118,6 +118,7 @@ class HttpClient[C, M[_]](implicit urls: GithubApiUrls,
   def get[A](
       accessToken: Option[String] = None,
       method: String,
+      headers: Map[String, String] = Map.empty,
       params: Map[String, String] = Map.empty,
       pagination: Option[Pagination] = None
   )(implicit D: Decoder[A]): M[GHResponse[A]] =
@@ -128,8 +129,10 @@ class HttpClient[C, M[_]](implicit urls: GithubApiUrls,
           Map("page" → p.page.toString, "per_page" → p.per_page.toString)))
     )
 
-  def patch[A](accessToken: Option[String] = None, method: String, data: String)(
-      implicit D: Decoder[A]): M[GHResponse[A]] =
+  def patch[A](accessToken: Option[String] = None,
+               method: String,
+               headers: Map[String, String] = Map.empty,
+               data: String)(implicit D: Decoder[A]): M[GHResponse[A]] =
     httpRbImpl.run[A](
       httpRequestBuilder(buildURL(method)).patchMethod.withAuth(accessToken).withData(data))
 
@@ -162,6 +165,7 @@ class HttpClient[C, M[_]](implicit urls: GithubApiUrls,
 
   def postOAuth[A](
       url: String,
+      headers: Map[String, String] = Map.empty,
       data: String
   )(implicit D: Decoder[A]): M[GHResponse[A]] =
     httpRbImpl.run[A](
@@ -169,8 +173,10 @@ class HttpClient[C, M[_]](implicit urls: GithubApiUrls,
         .withHeaders(Map("Accept" → "application/json"))
         .withData(data))
 
-  def delete[A](accessToken: Option[String] = None, method: String)(
-      implicit D: Decoder[A]): M[GHResponse[A]] =
+  def delete[A](
+      accessToken: Option[String] = None,
+      method: String,
+      headers: Map[String, String] = Map.empty)(implicit D: Decoder[A]): M[GHResponse[A]] =
     httpRbImpl.run[A](httpRequestBuilder(buildURL(method)).deleteMethod.withAuth(accessToken))
 
   private def buildURL(method: String) = urls.baseUrl + method

--- a/github4s/shared/src/main/scala/github4s/api/Auth.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Auth.scala
@@ -52,6 +52,7 @@ class Auth[C, M[_]](implicit urls: GithubApiUrls,
     * @param note to remind you what the OAuth token is for
     * @param client_id the 20 character OAuth app client key for which to create the token
     * @param client_secret the 40 character OAuth app client secret for which to create the token
+    * @param headers optional user headers to include in the request
     * @return GHResponse[Authorization] new authorization with access_token
     */
   def newAuth(
@@ -60,11 +61,12 @@ class Auth[C, M[_]](implicit urls: GithubApiUrls,
       scopes: List[String],
       note: String,
       client_id: String,
-      client_secret: String
+      client_secret: String,
+      headers: Map[String, String] = Map()
   ): M[GHResponse[Authorization]] =
     httpClient.postAuth[Authorization](
       method = "authorizations",
-      headers = Map("Authorization" → s"Basic ${s"$username:$password".getBytes.toBase64}"),
+      headers = Map("Authorization" → s"Basic ${s"$username:$password".getBytes.toBase64}") ++ headers,
       data = NewAuthRequest(scopes, note, client_id, client_secret).asJson.noSpaces
     )
 
@@ -103,6 +105,7 @@ class Auth[C, M[_]](implicit urls: GithubApiUrls,
     * @param code the code you received as a response to Step 1
     * @param redirect_uri the URL in your app where users will be sent after authorization
     * @param state the unguessable random string you optionally provided in Step 1
+    * @param headers optional user headers to include in the request
     * @return GHResponse[OAuthToken] new access_token: second step oAuth
     */
   def getAccessToken(
@@ -110,9 +113,11 @@ class Auth[C, M[_]](implicit urls: GithubApiUrls,
       client_secret: String,
       code: String,
       redirect_uri: String,
-      state: String
+      state: String,
+      headers: Map[String, String] = Map()
   ): M[GHResponse[OAuthToken]] = httpClient.postOAuth[OAuthToken](
     url = accessTokenUrl,
+    headers = headers,
     data = NewOAuthRequest(client_id, client_secret, code, redirect_uri, state).asJson.noSpaces
   )
 

--- a/github4s/shared/src/main/scala/github4s/api/Gists.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Gists.scala
@@ -43,15 +43,18 @@ class Gists[C, M[_]](implicit urls: GithubApiUrls,
     * @param description of the gist
     * @param public boolean value that describes if the Gist should be public or not
     * @param files map describing the filenames of the Gist and its contents
+    * @param headers optional user headers to include in the request
     * @param accessToken to identify the authenticated user
     */
   def newGist(description: String,
               public: Boolean,
               files: Map[String, GistFile],
+              headers: Map[String, String] = Map(),
               accessToken: Option[String] = None): M[GHResponse[Gist]] =
     httpClient.post[Gist](
       accessToken,
       "gists",
+      headers,
       data = NewGistRequest(description, public, files).asJson.noSpaces
     )
 

--- a/github4s/shared/src/main/scala/github4s/api/Repos.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Repos.scala
@@ -40,19 +40,22 @@ class Repos[C, M[_]](implicit urls: GithubApiUrls,
     * Get information of a particular repository
     *
     * @param accessToken to identify the authenticated user
+    * @param headers optional user headers to include in the request
     * @param owner of the repo
     * @param repo name of the repo
     * @return GHResponse[Repository] repository details
     */
   def get(accessToken: Option[String] = None,
+          headers: Map[String, String] = Map(),
           owner: String,
           repo: String): M[GHResponse[Repository]] =
-    httpClient.get[Repository](accessToken, s"repos/$owner/$repo")
+    httpClient.get[Repository](accessToken, s"repos/$owner/$repo", headers)
 
   /**
     * Retrieve the list of commits for a particular repo
     *
     * @param accessToken to identify the authenticated user
+    * @param headers optional user headers to include in the request
     * @param owner of the repo
     * @param repo name of the repo
     * @param sha branch to start listing commits from
@@ -65,6 +68,7 @@ class Repos[C, M[_]](implicit urls: GithubApiUrls,
     */
   def listCommits(
       accessToken: Option[String] = None,
+      headers: Map[String, String] = Map(),
       owner: String,
       repo: String,
       sha: Option[String] = None,
@@ -76,6 +80,7 @@ class Repos[C, M[_]](implicit urls: GithubApiUrls,
   ): M[GHResponse[List[Commit]]] =
     httpClient.get[List[Commit]](accessToken,
                                  s"repos/$owner/$repo/commits",
+                                 headers,
                                  Map(
                                    "sha"    → sha,
                                    "path"   → path,
@@ -92,6 +97,7 @@ class Repos[C, M[_]](implicit urls: GithubApiUrls,
     * sorted by the number of commits per contributor in descending order.
     *
     * @param accessToken to identify the authenticated user
+    * @param headers optional user headers to include in the request
     * @param owner of the repo
     * @param repo name of the repo
     * @param anon Set to 1 or true to include anonymous contributors in results
@@ -99,12 +105,14 @@ class Repos[C, M[_]](implicit urls: GithubApiUrls,
     */
   def listContributors(
       accessToken: Option[String] = None,
+      headers: Map[String, String] = Map(),
       owner: String,
       repo: String,
       anon: Option[String] = None
   ): M[GHResponse[List[User]]] =
     httpClient.get[List[User]](accessToken,
                                s"repos/$owner/$repo/contributors",
+                               headers,
                                Map(
                                  "anon" → anon
                                ).collect {

--- a/github4s/shared/src/main/scala/github4s/api/Users.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Users.scala
@@ -38,33 +38,41 @@ class Users[C, M[_]](implicit urls: GithubApiUrls,
     * Get information for a particular user
     *
     * @param accessToken to identify the authenticated user
+    * @param headers optional user headers to include in the request
     * @param username of the user to retrieve
     * @return GHResponse[User] User details
     */
-  def get(accessToken: Option[String] = None, username: String): M[GHResponse[User]] =
-    httpClient.get[User](accessToken, s"users/$username")
+  def get(accessToken: Option[String] = None,
+          headers: Map[String, String] = Map(),
+          username: String): M[GHResponse[User]] =
+    httpClient.get[User](accessToken, s"users/$username", headers)
 
   /**
     * Get information of the authenticated user
     * @param accessToken to identify the authenticated user
+    * @param headers optional user headers to include in the request
     * @return GHResponse[User] User details
     */
-  def getAuth(accessToken: Option[String] = None): M[GHResponse[User]] =
-    httpClient.get[User](accessToken, "user")
+  def getAuth(accessToken: Option[String] = None,
+              headers: Map[String, String] = Map()): M[GHResponse[User]] =
+    httpClient.get[User](accessToken, "user", headers)
 
   /**
     * Get users
     *
     * @param accessToken to identify the authenticated user
+    * @param headers optional user headers to include in the request
     * @param since The integer ID of the last User that you've seen.
     * @param pagination Limit and Offset for pagination
     * @return GHResponse[List[User] ] List of user's details
     */
   def getUsers(
       accessToken: Option[String] = None,
+      headers: Map[String, String] = Map(),
       since: Int,
       pagination: Option[Pagination] = None
   ): M[GHResponse[List[User]]] =
-    httpClient.get[List[User]](accessToken, "users", Map("since" → since.toString), pagination)
+    httpClient
+      .get[List[User]](accessToken, "users", headers, Map("since" → since.toString), pagination)
 
 }


### PR DESCRIPTION
This PR includes code to let users of the api to include custom headers (i.e.: "user-agent", ...) in their API requests. To achieve this, several changes have been introduced:

* Interpreters now perform a natural transformation from our algebras to a Kleisli that carries the header data.
* New exec functions have been implemented to make the access to the API easier for users (i.e.: `execK` exposes the inner Kleisli, `exec` allows the same behavior as before while letting users add headers to the requests as an optional parameter, and `execFuture` allows easier access to `Future` versions of the API for scala-js users).

Could you please review, @raulraja @juanpedromoreno? Thanks!