### PR TITLE
Better exception messages

### DIFF
--- a/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
+++ b/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
@@ -74,7 +74,8 @@ trait HttpRequestBuilderExtensionJVM {
       )
     case r ⇒
       Either.left(
-        UnexpectedException(s"Failed invoking get with status : ${r.code}, body : \n ${r.body}"))
+        UnexpectedException(
+          s"Request to $url failed with status : ${r.code}, body : \n ${r.body}"))
   }
 
   private def toLowerCase(


### PR DESCRIPTION
I assumed the `url` param to `toEntity` was there for some purpose.

We can also go the other way around and remove it altogether and not have the url in the exception message.