### PR TITLE
Made request success check consistent between scala and scala js

### DIFF
--- a/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
+++ b/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
@@ -24,7 +24,7 @@ import fr.hmil.roshttp.body.BulkBodyPart
 import fr.hmil.roshttp.response.SimpleHttpResponse
 import fr.hmil.roshttp.util.HeaderMap
 import github4s.GithubResponses._
-import github4s.HttpClient.HttpCode400
+import github4s.HttpClient.{HttpCode200, HttpCode299}
 import io.circe.Decoder
 import io.circe.parser._
 
@@ -69,7 +69,7 @@ trait HttpRequestBuilderExtensionJS {
 
   def toEntity[A](response: SimpleHttpResponse)(implicit D: Decoder[A]): GHResponse[A] =
     response match {
-      case r if r.statusCode < HttpCode400.statusCode ⇒
+      case r if r.statusCode <= HttpCode299.statusCode && r.statusCode >= HttpCode200.statusCode ⇒
         decode[A](r.body).fold(
           e ⇒ Either.left(JsonParsingException(e.getMessage, r.body)),
           result ⇒

--- a/github4s/shared/src/main/scala/github4s/HttpClient.scala
+++ b/github4s/shared/src/main/scala/github4s/HttpClient.scala
@@ -52,8 +52,12 @@ object HttpClient {
     def statusCode: Int
   }
 
-  case object HttpCode400 extends HttpStatus {
-    def statusCode = 400
+  case object HttpCode200 extends HttpStatus {
+    def statusCode = 200
+  }
+
+  case object HttpCode299 extends HttpStatus {
+    def statusCode = 299
   }
 }
 


### PR DESCRIPTION
This conforms to [scalaj's way of checking that a request has succeeded](https://github.com/scalaj/scalaj-http/blob/master/src/main/scala/scalaj/http/Http.scala#L131) and avoid the fact that you could have a 3xx (hopefully that's not something that github returns) that succeeds with scala js but fails in the jvm.