### PR TITLE
Remove integration tests creating statuses

### DIFF
--- a/github4s/shared/src/test/scala/github4s/integration/GHStatusesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHStatusesSpec.scala
@@ -63,37 +63,4 @@ trait GHStatusesSpec[T] extends BaseIntegrationSpec[T] {
       r.statusCode shouldBe okStatusCode
     })
   }
-
-  "Statuses >> Create" should "create a status" in {
-    val response = Github(accessToken).statuses
-      .createStatus(
-        validRepoOwner,
-        validRepoName,
-        validCommitSha,
-        validStatusState,
-        None,
-        None,
-        None)
-      .execFuture[T](headerUserAgent)
-
-    testFutureIsRight[Status](response, { r =>
-      r.result.state shouldBe validStatusState
-      r.statusCode shouldBe createdStatusCode
-    })
-  }
-
-  it should "return an error when an invalid sha is passed" in {
-    val response = Github(accessToken).statuses
-      .createStatus(
-        validRepoOwner,
-        validRepoName,
-        invalidCommitSha,
-        validStatusState,
-        None,
-        None,
-        None)
-      .execFuture[T](headerUserAgent)
-
-    testFutureIsLeft(response)
-  }
 }


### PR DESCRIPTION
This is causing the current builds to fail as we've recently reached the limit of 1k statuses for the commit sha we use to create statuses in the integration tests.