### PR TITLE
Fixes cats-effects ScalaJS tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val scalaz = (project in file("scalaz"))
 
 lazy val catsEffect = (crossProject in file("cats-effect"))
   .settings(moduleName := "github4s-cats-effect")
-  .settings(catsEffectDependencies: _*)
+  .crossDepSettings(catsEffectDependencies: _*)
   .jsSettings(sharedJsSettings: _*)
   .jsSettings(testSettings: _*)
   .dependsOn(github4s)

--- a/cats-effect/js/src/test/scala/github4s/cats/effect/js/CatsEffectJSSpec.scala
+++ b/cats-effect/js/src/test/scala/github4s/cats/effect/js/CatsEffectJSSpec.scala
@@ -20,32 +20,64 @@ import cats.effect.IO
 import github4s.Github
 import github4s.Github._
 import github4s.cats.effect.js.Implicits._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{Assertion, AsyncFunSuite, Matchers}
 import fr.hmil.roshttp.response.SimpleHttpResponse
+import github4s.GithubResponses.GHResponse
+import github4s.free.domain.User
+import org.scalactic.source.Position
 
-class CatsEffectJSSpec extends FlatSpec with Matchers {
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}
+import scala.util.Try
+
+class CatsEffectJSSpec extends AsyncFunSuite with Matchers {
+
+  implicit override def executionContext: ExecutionContextExecutor = ExecutionContext.global
+
+  def testEffectOnRunAsync[A](source: IO[GHResponse[A]], f: GHResponse[A] => Assertion)(
+      implicit pos: Position): Future[Assertion] = {
+
+    val effect  = Promise[GHResponse[A]]()
+    val attempt = Promise[Try[GHResponse[A]]]()
+    effect.future.onComplete(attempt.success)
+
+    val io = source.runAsync {
+      case Right(s) => IO(effect.success(s))
+      case Left(e)  => IO(effect.failure(e))
+    }
+
+    for (_ <- io.unsafeToFuture(); v <- attempt.future) yield {
+      v.toOption
+        .map { result =>
+          f(result)
+        }
+        .getOrElse(fail("effect attempt failed"))
+    }
+  }
+
   val accessToken     = sys.env.get("GITHUB4S_ACCESS_TOKEN")
   val headerUserAgent = Map("user-agent" -> "github4s")
   val validUsername   = "rafaparadela"
   val invalidUsername = "GHInvalidUserName"
   val okStatusCode    = 200
 
-  "cats-effect js integration" should "return a succeded result for a valid call" in {
+  test("return a succeded result for a valid call") {
     val response = Github(accessToken).users
       .get(validUsername)
       .exec[IO, SimpleHttpResponse](headerUserAgent)
 
-    val res = response.unsafeRunSync
-    res.isRight shouldBe true
-    res.right.map(_.statusCode) shouldBe Right(okStatusCode)
+    testEffectOnRunAsync(response, { r: GHResponse[User] =>
+      r.isRight shouldBe true
+      r.right.map(_.statusCode) shouldBe Right(okStatusCode)
+    })
   }
 
-  it should "return a failed result for an invalid call" in {
+  test("return a failed result for an invalid call") {
     val response = Github(accessToken).users
       .get(invalidUsername)
       .exec[IO, SimpleHttpResponse](headerUserAgent)
 
-    val res = response.unsafeRunSync
-    res.isLeft shouldBe true
+    testEffectOnRunAsync(response, { r: GHResponse[User] =>
+      r.isLeft shouldBe true
+    })
   }
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -74,8 +74,8 @@ object ProjectPlugin extends AutoPlugin {
     lazy val scalazDependencies: Def.Setting[Seq[ModuleID]] =
       libraryDependencies += %%("scalaz-concurrent")
 
-    lazy val catsEffectDependencies: Def.Setting[Seq[ModuleID]] =
-      libraryDependencies ++= Seq(
+    lazy val catsEffectDependencies: Seq[ModuleID] =
+      Seq(
         %%("cats-effect"),
         %%("scalatest") % "test"
       )
@@ -109,7 +109,7 @@ object ProjectPlugin extends AutoPlugin {
       orgSupportedScalaJSVersion := Some("0.6.15"),
       orgScriptTaskListSetting ++= List(
         (ScoverageKeys.coverageAggregate in Test).asRunnableItemFull,
-       "docs/tut".asRunnableItem
+        "docs/tut".asRunnableItem
       ),
       coverageExcludedPackages := "<empty>;github4s\\.scalaz\\..*;github4s\\.cats\\.effect\\..*",
       // This is necessary to prevent packaging the BuildInfo with

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin(
-  "com.47deg" % "sbt-org-policies" % "0.5.2" exclude ("io.get-coursier", "sbt-coursier"))
+  "com.47deg" % "sbt-org-policies" % "0.5.4" exclude ("io.get-coursier", "sbt-coursier"))


### PR DESCRIPTION
This PR solves the sbt configuration to allow run tests for scalajs cross building (`crossDepSettings `).

On the other hand, there was a problem in tests because:
`java.lang.UnsupportedOperationException: cannot synchronously await result on JavaScript; use runAsync or unsafeRunAsync`

Hence, I also fixed both existing tests with the recommended way to do it.

Feel free to merge it if this makes sense to you.