### PR TITLE
Bump travis 2.12 version to 2.12.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: precise
 scala:
 - 2.10.6
 - 2.11.11
-- 2.12.2
+- 2.12.3
 
 jdk:
 - oraclejdk8


### PR DESCRIPTION
github4s is pulling the crossScalaVersions from sbt-org-policies. It has `2.12` has `2.12.3` which is different than travis's `2.12.2`. The `release` task has a filter that only allows it to run for the latest `crossScalaVersion`.

Reference links in some order:
https://github.com/47deg/sbt-org-policies/blob/v0.7.5/core/src/main/scala/sbtorgpolicies/model.scala#L138

https://github.com/47deg/github4s/blob/master/project/ProjectPlugin.scala#L94

https://travis-ci.org/47deg/github4s/jobs/279420156#L2119
https://travis-ci.org/47deg/github4s/jobs/279420156#L2121