### PR TITLE
Make PullRequestFile#patch an Option[String]

### DIFF
--- a/github4s/shared/src/main/scala/github4s/free/domain/PullRequest.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/PullRequest.scala
@@ -50,7 +50,7 @@ case class PullRequestFile(
     blob_url: String,
     raw_url: String,
     contents_url: String,
-    patch: String,
+    patch: Option[String],
     previous_filename: Option[String])
 sealed trait CreatePullRequest {
   def head: String

--- a/github4s/shared/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
@@ -71,6 +71,18 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
+  "PullRequests >> ListFiles" should "return a right response when a valid repo is provided and not all files have 'patch'" in {
+    val response =
+      Github(None).pullRequests
+        .listFiles("scala", "scala", 4877)
+        .execFuture[T](headerUserAgent)
+
+    testFutureIsRight[List[PullRequestFile]](response, { r =>
+      r.result.nonEmpty shouldBe true
+      r.statusCode shouldBe okStatusCode
+    })
+  }
+
   it should "return error when an invalid repo name is passed" in {
     val response =
       Github(accessToken).pullRequests

--- a/github4s/shared/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/TestData.scala
@@ -208,7 +208,7 @@ trait TestData extends DummyGithubUrls {
     blob_url = githubApiUrl,
     raw_url = githubApiUrl,
     contents_url = githubApiUrl,
-    patch = "",
+    patch = None,
     previous_filename = None
   )
 


### PR DESCRIPTION
Closes #180

That field is not populated on binary files.

Example: `$ curl https://api.github.com/repos/scala/scala/pulls/4877/files | jq '. | map(select(.patch == null))'`

```json
[
  {
    "sha": "7229603ae5b30ce0e0bd09863543b260085c8f2d",
    "filename": "src/scaladoc/scala/tools/nsc/doc/html/resource/lib/arrow-down.png",
    "status": "removed",
    "additions": 0,
    "deletions": 0,
    "changes": 0,
    "blob_url": "https://github.com/scala/scala/blob/da3720e55b3d69cc31ab0f26e6cffafb18da360f/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/arrow-down.png",
    "raw_url": "https://github.com/scala/scala/raw/da3720e55b3d69cc31ab0f26e6cffafb18da360f/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/arrow-down.png",
    "contents_url": "https://api.github.com/repos/scala/scala/contents/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/arrow-down.png?ref=da3720e55b3d69cc31ab0f26e6cffafb18da360f"
  },
  ...
]
```