### PR TITLE
Bump ruby version in travis to fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 - export PATH=${PATH}:./vendor/bundle
 
 install:
-- rvm use 2.2.3 --install --fuzzy
+- rvm use 2.2.8 --install --fuzzy
 - gem update --system
 - gem install sass
 - gem install jekyll -v 3.2.1


### PR DESCRIPTION
Ruby 2.2.3 does not meet the version constraint of a transitive dependency.
This change fixes the travis build failure in recent PRs.