### PR TITLE
Fixes Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: scala
 
-dist: precise
-
 scala:
 - 2.10.6
 - 2.11.11
@@ -20,7 +18,8 @@ install:
 - rvm use 2.2.8 --install --fuzzy
 - gem update --system
 - gem install sass
-- gem install jekyll -v 3.2.1
+- gem install ruby_dep -v 1.3.1
+- gem install jekyll -v 3.4.3
 - gem install jekyll-redirect-from
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,15 +64,13 @@ jobs:
             if grep -q "SNAPSHOT" version.sbt; then
               sbt ++$TRAVIS_SCALA_VERSION publish;
             else
-              if [ "$SCALAENV" = "all" ]; then
-                sbt orgUpdateDocFiles;
-                git reset --hard HEAD;
-                git clean -f;
-                git checkout master;
-                git pull origin master;
-                sbt release;
-                sbt docs/publishMicrosite;
-              fi
+              sbt orgUpdateDocFiles;
+              git reset --hard HEAD;
+              git clean -f;
+              git checkout master;
+              git pull origin master;
+              sbt release;
+              sbt docs/publishMicrosite;
             fi
           fi
       scala: 2.12.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
   exclude:
   - scala: 2.10.7
     env: FREESBUILD=docs
-  exclude:
   - scala: 2.11.12
     env: FREESBUILD=docs
   - env: SCALAENV=all

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ env:
 - SCALAENV=jvm
 - SCALAENV=js
 - SCALAENV=all
-- FREESBUILD=docs
+- G4SBUILD=docs
 
 matrix:
   exclude:
   - scala: 2.10.7
-    env: FREESBUILD=docs
+    env: G4SBUILD=docs
   - scala: 2.11.12
-    env: FREESBUILD=docs
+    env: G4SBUILD=docs
   - env: SCALAENV=all
 
 jdk:
@@ -43,9 +43,9 @@ script:
 - if [ "$SCALAENV" = "jvm" ]; then
     sbt ++$TRAVIS_SCALA_VERSION validateJVM;
   elif [ "$SCALAENV" = "js" ]; then
-    sbt ++$TRAVIS_SCALA_VERSION test:fastOptJS;
+    sbt ++$TRAVIS_SCALA_VERSION compile;
     sbt ++$TRAVIS_SCALA_VERSION validateJS;
-  elif [ "$FREESBUILD" = "docs" ]; then
+  elif [ "$G4SBUILD" = "docs" ]; then
     sbt ++$TRAVIS_SCALA_VERSION docs/tut;
   else
     echo "You might not be invited to the party";

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
 language: scala
 
 scala:
-- 2.10.6
-- 2.11.11
+- 2.10.7
+- 2.11.12
 - 2.12.4
+
+env:
+- SCALAENV=jvm
+- SCALAENV=js
+- SCALAENV=all
+- FREESBUILD=docs
+
+matrix:
+  exclude:
+  - scala: 2.10.7
+    env: FREESBUILD=docs
+  exclude:
+  - scala: 2.11.12
+    env: FREESBUILD=docs
+  - env: SCALAENV=all
 
 jdk:
 - oraclejdk8
@@ -26,12 +41,40 @@ before_script:
   - sudo chmod +x /usr/local/bin/sbt
 
 script:
-- sbt ++$TRAVIS_SCALA_VERSION test:fastOptJS
-- sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
+- if [ "$SCALAENV" = "jvm" ]; then
+    sbt ++$TRAVIS_SCALA_VERSION validateJVM;
+  elif [ "$SCALAENV" = "js" ]; then
+    sbt ++$TRAVIS_SCALA_VERSION validateJS;
+  elif [ "$FREESBUILD" = "docs" ]; then
+    sbt ++$TRAVIS_SCALA_VERSION docs/tut;
+  else
+    echo "You might not be invited to the party";
+  fi
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)
-- sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
+
+jobs:
+  include:
+    - stage: deploy
+      script:
+        - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+            if grep -q "SNAPSHOT" version.sbt; then
+              sbt ++$TRAVIS_SCALA_VERSION publish;
+            else
+              if [ "$SCALAENV" = "all" ]; then
+                sbt orgUpdateDocFiles;
+                git reset --hard HEAD;
+                git clean -f;
+                git checkout master;
+                git pull origin master;
+                sbt release;
+                sbt docs/publishMicrosite;
+              fi
+            fi
+          fi
+      scala: 2.12.4
+      env: SCALAENV=all
 
 before_cache:
   - du -h -d 1 $HOME/.ivy2/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
 - if [ "$SCALAENV" = "jvm" ]; then
     sbt ++$TRAVIS_SCALA_VERSION validateJVM;
   elif [ "$SCALAENV" = "js" ]; then
+    sbt ++$TRAVIS_SCALA_VERSION test:fastOptJS;
     sbt ++$TRAVIS_SCALA_VERSION validateJS;
   elif [ "$FREESBUILD" = "docs" ]; then
     sbt ++$TRAVIS_SCALA_VERSION docs/tut;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
 
+dist: precise
+
 scala:
 - 2.10.7
 - 2.11.12

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
 
 lazy val root = (project in file("."))
+  .settings(moduleName := "github4s-root")
   .aggregate(allModules: _*)
   .dependsOn(allModulesDeps: _*)
   .settings(noPublishSettings: _*)
@@ -25,16 +26,9 @@ lazy val github4s = (crossProject in file("github4s"))
   .jsSettings(jsDeps: _*)
   .jsSettings(sharedJsSettings: _*)
   .jsSettings(testSettings: _*)
+
 lazy val github4sJVM = github4s.jvm
 lazy val github4sJS  = github4s.js
-
-lazy val docs = (project in file("docs"))
-  .dependsOn(scalaz, catsEffectJVM, catsEffectJS)
-  .settings(moduleName := "github4s-docs")
-  .settings(micrositeSettings: _*)
-  .settings(docsDependencies: _*)
-  .settings(noPublishSettings: _*)
-  .enablePlugins(MicrositesPlugin)
 
 lazy val scalaz = (project in file("scalaz"))
   .settings(moduleName := "github4s-scalaz")
@@ -70,6 +64,22 @@ lazy val allModules: Seq[ProjectReference] = jvmModules ++ jsModules
 
 lazy val allModulesDeps: Seq[ClasspathDependency] =
   allModules.map(ClasspathDependency(_, None))
+
+//////////
+// DOCS //
+//////////
+
+lazy val docs = (project in file("docs"))
+  .dependsOn(allModulesDeps: _*)
+  .settings(moduleName := "github4s-docs")
+  .settings(micrositeSettings: _*)
+  .settings(docsDependencies: _*)
+  .settings(noPublishSettings: _*)
+  .enablePlugins(MicrositesPlugin)
+
+//////////
+// MISC //
+//////////
 
 addCommandAlias("validateDocs", ";project docs;tut;project root")
 addCommandAlias(

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,12 @@
+import sbtorgpolicies.runnable.syntax._
+
 pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
 pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
 
 lazy val root = (project in file("."))
-  .dependsOn(github4sJVM, github4sJS, scalaz, catsEffectJVM, catsEffectJS, docs)
-  .aggregate(github4sJVM, github4sJS, scalaz, catsEffectJVM, catsEffectJS, docs)
+  .aggregate(allModules: _*)
+  .dependsOn(allModulesDeps: _*)
   .settings(noPublishSettings: _*)
 
 lazy val github4s = (crossProject in file("github4s"))
@@ -48,3 +50,32 @@ lazy val catsEffect = (crossProject in file("cats-effect"))
 
 lazy val catsEffectJVM = catsEffect.jvm
 lazy val catsEffectJS  = catsEffect.js
+
+/////////////////////
+//// ALL MODULES ////
+/////////////////////
+
+lazy val jvmModules: Seq[ProjectReference] = Seq(
+  github4sJVM,
+  scalaz,
+  catsEffectJVM
+)
+
+lazy val jsModules: Seq[ProjectReference] = Seq(
+  github4sJS,
+  catsEffectJS
+)
+
+lazy val allModules: Seq[ProjectReference] = jvmModules ++ jsModules
+
+lazy val allModulesDeps: Seq[ClasspathDependency] =
+  allModules.map(ClasspathDependency(_, None))
+
+addCommandAlias("validateDocs", ";project docs;tut;project root")
+addCommandAlias(
+  "validateJVM",
+  (toCompileTestList(jvmModules) ++ List("project root")).asCmd)
+addCommandAlias("validateJS", (toCompileTestList(jsModules) ++ List("project root")).asCmd)
+addCommandAlias(
+  "validate",
+  ";clean;compile;coverage;validateJVM;coverageReport;coverageAggregate;coverageOff")

--- a/cats-effect/js/src/main/scala/github4s/cats/effect/IOHttpRequestBuilderExtensionJS.scala
+++ b/cats-effect/js/src/main/scala/github4s/cats/effect/IOHttpRequestBuilderExtensionJS.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cats-effect/js/src/main/scala/github4s/cats/effect/js/Implicits.scala
+++ b/cats-effect/js/src/main/scala/github4s/cats/effect/js/Implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cats-effect/js/src/main/scala/github4s/cats/effect/js/ImplicitsJS.scala
+++ b/cats-effect/js/src/main/scala/github4s/cats/effect/js/ImplicitsJS.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cats-effect/js/src/test/scala/github4s/cats/effect/js/CatsEffectJSSpec.scala
+++ b/cats-effect/js/src/test/scala/github4s/cats/effect/js/CatsEffectJSSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cats-effect/shared/src/main/scala/github4s/cats/effect/IOCaptureInstance.scala
+++ b/cats-effect/shared/src/main/scala/github4s/cats/effect/IOCaptureInstance.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
+++ b/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/js/src/main/scala/github4s/js/Implicits.scala
+++ b/github4s/js/src/main/scala/github4s/js/Implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/js/src/main/scala/github4s/js/ImplicitsJS.scala
+++ b/github4s/js/src/main/scala/github4s/js/ImplicitsJS.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/js/src/main/scala/github4s/util/URLEncoder.scala
+++ b/github4s/js/src/main/scala/github4s/util/URLEncoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/js/src/test/scala/github4s/integration/IntegrationSpec.scala
+++ b/github4s/js/src/test/scala/github4s/integration/IntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/js/src/test/scala/github4s/utils/TestUtilsJS.scala
+++ b/github4s/js/src/test/scala/github4s/utils/TestUtilsJS.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
+++ b/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/main/scala/github4s/jvm/Implicits.scala
+++ b/github4s/jvm/src/main/scala/github4s/jvm/Implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/main/scala/github4s/jvm/ImplicitsJVM.scala
+++ b/github4s/jvm/src/main/scala/github4s/jvm/ImplicitsJVM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/main/scala/github4s/util/URLEncoder.scala
+++ b/github4s/jvm/src/main/scala/github4s/util/URLEncoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/test/scala/github4s/integration/IntegrationSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/integration/IntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/test/scala/github4s/unit/ApiSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/unit/ApiSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/test/scala/github4s/utils/MockGithubApiServer.scala
+++ b/github4s/jvm/src/test/scala/github4s/utils/MockGithubApiServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/test/scala/github4s/utils/MockServerService.scala
+++ b/github4s/jvm/src/test/scala/github4s/utils/MockServerService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/jvm/src/test/scala/github4s/utils/TestUtilsJVM.scala
+++ b/github4s/jvm/src/test/scala/github4s/utils/TestUtilsJVM.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/Decoders.scala
+++ b/github4s/shared/src/main/scala/github4s/Decoders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/Encoders.scala
+++ b/github4s/shared/src/main/scala/github4s/Encoders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/Github.scala
+++ b/github4s/shared/src/main/scala/github4s/Github.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/GithubAPIs.scala
+++ b/github4s/shared/src/main/scala/github4s/GithubAPIs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/GithubDefaultUrls.scala
+++ b/github4s/shared/src/main/scala/github4s/GithubDefaultUrls.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/GithubResponses.scala
+++ b/github4s/shared/src/main/scala/github4s/GithubResponses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/HttpClient.scala
+++ b/github4s/shared/src/main/scala/github4s/HttpClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/HttpClientExtension.scala
+++ b/github4s/shared/src/main/scala/github4s/HttpClientExtension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/Implicits.scala
+++ b/github4s/shared/src/main/scala/github4s/Implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/Activities.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Activities.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/Auth.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Auth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/Gists.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Gists.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/GitData.scala
+++ b/github4s/shared/src/main/scala/github4s/api/GitData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/Issues.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Issues.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/Organizations.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Organizations.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/PullRequests.scala
+++ b/github4s/shared/src/main/scala/github4s/api/PullRequests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/Repos.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Repos.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/Users.scala
+++ b/github4s/shared/src/main/scala/github4s/api/Users.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/api/package.scala
+++ b/github4s/shared/src/main/scala/github4s/api/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/app.scala
+++ b/github4s/shared/src/main/scala/github4s/app.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/ActivityOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/ActivityOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/AuthOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/AuthOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/GistOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/GistOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/GitDataOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/GitDataOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/IssuesOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/IssuesOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/OrganizationOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/OrganizationOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/PullRequestOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/PullRequestOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/RepositoryOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/RepositoryOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/algebra/UserOps.scala
+++ b/github4s/shared/src/main/scala/github4s/free/algebra/UserOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/Activity.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/Activity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/Authorization.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/Authorization.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/Gist.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/Gist.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/GitData.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/GitData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/Issue.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/Issue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/Pagination.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/Pagination.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/PullRequest.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/PullRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/Repository.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/Repository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/SearchParam.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/SearchParam.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/domain/User.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/User.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/main/scala/github4s/free/interpreters/Interpreters.scala
+++ b/github4s/shared/src/main/scala/github4s/free/interpreters/Interpreters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/integration/GHActivitiesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHActivitiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/integration/GHAuthSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHAuthSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/integration/GHGitDataSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHGitDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/integration/GHIssuesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHIssuesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/integration/GHOrganizationsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHOrganizationsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/integration/GHReposSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHReposSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/integration/GHUsersSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHUsersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/ActivitiesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/ActivitiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/AuthSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/AuthSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/DecodersSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/DecodersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/EncodersSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/EncodersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHActivitiesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHActivitiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHAuthSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHAuthSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHGistSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHGistSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHGitDataSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHGitDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHIssuesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHIssuesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHOrganizationsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHOrganizationsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHPullRequestsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHPullRequestsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHReposSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHReposSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GHUserSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GHUserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GistSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GistSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/GitDataSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/GitDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/IssuesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/IssuesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/OrganizationssSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/OrganizationssSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/PullRequestsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/PullRequestsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/ReposSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/ReposSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/unit/UserSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/unit/UserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/utils/BaseIntegrationSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/BaseIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/utils/BaseSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/utils/DummyGithubUrls.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/DummyGithubUrls.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/utils/FakeResponses.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/FakeResponses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/github4s/shared/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -81,6 +81,12 @@ object ProjectPlugin extends AutoPlugin {
         %%("cats-effect"),
         %%("scalatest") % "test"
       )
+
+    def toCompileTestList(sequence: Seq[ProjectReference]): List[String] = sequence.toList.map {
+      p =>
+        val project: String = p.asInstanceOf[LocalProject].project
+        s"$project/test"
+    }
   }
 
   override def projectSettings: Seq[Def.Setting[_]] =


### PR DESCRIPTION
It seems the precise environment has been decommissioned...

https://github.com/47deg/github4s/commit/d49b540c247b7aea5ad2f931fa9495fbb7c56408 will fix the issue? No.

The latest commits, besides the files header update, bring build pipelines in Travis, which makes lightweight builds based on the Scala Version.