### PR TITLE
# Make `body: Option[String]`

### DIFF
--- a/github4s/shared/src/main/scala/github4s/free/domain/PullRequest.scala
+++ b/github4s/shared/src/main/scala/github4s/free/domain/PullRequest.scala
@@ -21,7 +21,7 @@ case class PullRequest(
     number: Int,
     state: String,
     title: String,
-    body: String,
+    body: Option[String],
     locked: Boolean,
     html_url: String,
     created_at: String,

--- a/github4s/shared/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
@@ -35,6 +35,18 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
+  "PullRequests >> List" should "return a right response when a valid repo is provided but not all pull requests have body" in {
+    val response =
+      Github(accessToken).pullRequests
+        .list("lloydmeta", "gh-test-repo", List(PRFilterOpen))
+        .execFuture[T](headerUserAgent)
+
+    testFutureIsRight[List[PullRequest]](response, { r =>
+      r.result.nonEmpty shouldBe true
+      r.statusCode shouldBe okStatusCode
+    })
+  }
+
   it should "return a non empty list when valid repo and some filters are provided" in {
     val response =
       Github(accessToken).pullRequests
@@ -73,7 +85,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
 
   "PullRequests >> ListFiles" should "return a right response when a valid repo is provided and not all files have 'patch'" in {
     val response =
-      Github(None).pullRequests
+      Github(accessToken).pullRequests
         .listFiles("scala", "scala", 4877)
         .execFuture[T](headerUserAgent)
 

--- a/github4s/shared/src/test/scala/github4s/utils/TestData.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/TestData.scala
@@ -185,7 +185,7 @@ trait TestData extends DummyGithubUrls {
     number = validPullRequestNumber,
     state = "open",
     title = "Title",
-    body = "Body",
+    body = Some("Body"),
     locked = false,
     html_url = githubApiUrl,
     created_at = "2011-04-10T20:09:31Z",


### PR DESCRIPTION
You can create a PR with `"body": null` if you use the API, or use a tool
that uses the API.

This PR makes `body: Option[String]`

```shell
curl -X GET https://api.github.com/repos/lloydmeta/gh-test-repo/pulls
[
  {
    "url": "https://api.github.com/repos/lloydmeta/gh-test-repo/pulls/3",
    // snip
    "body": null,
    // snip
  },
  {
    "url": "https://api.github.com/repos/lloydmeta/gh-test-repo/pulls/1",
    // snip
    "body": "",
    // snip
]
```