### PR TITLE
Keep circe decoders dry

### DIFF
--- a/github4s/shared/src/main/scala/github4s/Decoders.scala
+++ b/github4s/shared/src/main/scala/github4s/Decoders.scala
@@ -164,11 +164,11 @@ object Decoders {
 
   implicit val decodePRStatus: Decoder[PullRequestReviewState] =
     Decoder.decodeString.map {
-      case "APPROVED"          => PRRStateApproved
-      case "CHANGES_REQUESTED" => PRRStateChangesRequested
-      case "COMMENTED"         => PRRStateCommented
-      case "PENDING"           => PRRStatePending
-      case "DISMISSED"         => PRRStateDismissed
+      case PRRStateApproved.value         => PRRStateApproved
+      case PRRStateChangesRequested.value => PRRStateChangesRequested
+      case PRRStateCommented.value        => PRRStateCommented
+      case PRRStatePending.value          => PRRStatePending
+      case PRRStateDismissed.value        => PRRStateDismissed
     }
 
   implicit val decodeGist: Decoder[Gist] = Decoder.instance { c ⇒


### PR DESCRIPTION
Something small I noticed while implementing my own decoders for enums :+1: 