### PR TITLE
Release 0.18.8

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.18.7"
+version in ThisBuild := "0.18.8"


### PR DESCRIPTION
There was a travis timeout which resulted in the cats-effect artifact not being published.

I don't know if you can publish manually, otherwise let's go with 0.18.8.