### PR TITLE
Introduce a way to distinguish different github errors

### DIFF
--- a/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
+++ b/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
@@ -87,8 +87,10 @@ trait HttpRequestBuilderExtensionJS {
         mapResponse(r)
       case r ⇒
         Either.left(
-          UnexpectedException(
-            s"Failed invoking with status : ${r.statusCode}, body : \n ${r.body}"))
+          GithubHttpRequestUnsuccessful(
+            s"Failed invoking with status : ${r.statusCode}, body : \n ${r.body}",
+            r.statusCode
+          ))
     }
 
   def emptyResponse(r: SimpleHttpResponse): GHResponse[Unit] =

--- a/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
+++ b/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
@@ -87,7 +87,7 @@ trait HttpRequestBuilderExtensionJS {
         mapResponse(r)
       case r ⇒
         Either.left(
-          GithubHttpRequestUnsuccessful(
+          UnsuccessfulHttpRequest(
             s"Failed invoking with status : ${r.statusCode}, body : \n ${r.body}",
             r.statusCode
           ))

--- a/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
+++ b/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
@@ -78,7 +78,7 @@ trait HttpRequestBuilderExtensionJVM {
         mapResponse(r)
       case r ⇒
         Either.left(
-          GithubHttpRequestUnsuccessful(
+          UnsuccessfulHttpRequest(
             s"Failed invoking with status : ${r.code} body : \n ${r.body}",
             r.code
           )

--- a/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
+++ b/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
@@ -16,10 +16,9 @@
 
 package github4s
 
-import github4s.GithubResponses.{GHResponse, GHResult, JsonParsingException, UnexpectedException}
+import github4s.GithubResponses._
 import io.circe.Decoder
 import io.circe.parser._
-
 import scalaj.http._
 import cats.implicits._
 import github4s.free.interpreters.Capture
@@ -79,7 +78,11 @@ trait HttpRequestBuilderExtensionJVM {
         mapResponse(r)
       case r ⇒
         Either.left(
-          UnexpectedException(s"Failed invoking with status : ${r.code} body : \n ${r.body}"))
+          GithubHttpRequestUnsuccessful(
+            s"Failed invoking with status : ${r.code} body : \n ${r.body}",
+            r.code
+          )
+        )
     }
 
   def emptyResponse(r: HttpResponse[String]): GHResponse[Unit] =

--- a/github4s/shared/src/main/scala/github4s/GithubResponses.scala
+++ b/github4s/shared/src/main/scala/github4s/GithubResponses.scala
@@ -37,6 +37,11 @@ object GithubResponses {
       json: String
   ) extends GHException(msg)
 
+  case class GithubHttpRequestUnsuccessful(
+    msg: String,
+    statusCode: Int
+  ) extends GHException(msg)
+
   case class UnexpectedException(msg: String) extends GHException(msg)
 
 }

--- a/github4s/shared/src/main/scala/github4s/GithubResponses.scala
+++ b/github4s/shared/src/main/scala/github4s/GithubResponses.scala
@@ -37,7 +37,7 @@ object GithubResponses {
       json: String
   ) extends GHException(msg)
 
-  case class GithubHttpRequestUnsuccessful(
+  case class UnsuccessfulHttpRequest(
     msg: String,
     statusCode: Int
   ) extends GHException(msg)


### PR DESCRIPTION
I discovered that there is not way to distinguish between different type of errors in the application using github4s.
This small PR introduces another type for the errors, so the consumer get more information to deal with:
- ability to distinguish between HTTP errors (ie. file not found) and other
- ability to deal with HTTP errors differently based on status code