### PR TITLE
Replaces circe-jawn by circe-jackson Parser

### DIFF
--- a/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
+++ b/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
@@ -26,6 +26,7 @@ import fr.hmil.roshttp.util.HeaderMap
 import github4s.GithubResponses._
 import github4s.HttpClient.{HttpCode200, HttpCode299}
 import io.circe._
+import io.circe.jackson._
 import io.circe.syntax._
 
 import scala.concurrent.Future
@@ -97,8 +98,8 @@ trait HttpRequestBuilderExtensionJS {
     Either.right(GHResult((): Unit, r.statusCode, rosHeaderMapToRegularMap(r.headers)))
 
   def decodeEntity[A](r: SimpleHttpResponse)(implicit D: Decoder[A]): GHResponse[A] =
-    r.body.asJson
-      .as[A]
+    parse(r.body)
+      .flatMap(_.as[A])
       .bimap(
         e ⇒ JsonParsingException(e.getMessage, r.body),
         result ⇒ GHResult(result, r.statusCode, rosHeaderMapToRegularMap(r.headers))

--- a/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
+++ b/github4s/js/src/main/scala/github4s/HttpRequestBuilderExtensionJS.scala
@@ -25,8 +25,8 @@ import fr.hmil.roshttp.response.SimpleHttpResponse
 import fr.hmil.roshttp.util.HeaderMap
 import github4s.GithubResponses._
 import github4s.HttpClient.{HttpCode200, HttpCode299}
-import io.circe.Decoder
-import io.circe.parser._
+import io.circe._
+import io.circe.syntax._
 
 import scala.concurrent.Future
 
@@ -81,7 +81,7 @@ trait HttpRequestBuilderExtensionJS {
 
   def toEntity[A](
       response: SimpleHttpResponse,
-      mapResponse: (SimpleHttpResponse) => GHResponse[A]): GHResponse[A] =
+      mapResponse: SimpleHttpResponse => GHResponse[A]): GHResponse[A] =
     response match {
       case r if r.statusCode <= HttpCode299.statusCode && r.statusCode >= HttpCode200.statusCode ⇒
         mapResponse(r)
@@ -97,10 +97,12 @@ trait HttpRequestBuilderExtensionJS {
     Either.right(GHResult((): Unit, r.statusCode, rosHeaderMapToRegularMap(r.headers)))
 
   def decodeEntity[A](r: SimpleHttpResponse)(implicit D: Decoder[A]): GHResponse[A] =
-    decode[A](r.body).bimap(
-      e ⇒ JsonParsingException(e.getMessage, r.body),
-      result ⇒ GHResult(result, r.statusCode, rosHeaderMapToRegularMap(r.headers))
-    )
+    r.body.asJson
+      .as[A]
+      .bimap(
+        e ⇒ JsonParsingException(e.getMessage, r.body),
+        result ⇒ GHResult(result, r.statusCode, rosHeaderMapToRegularMap(r.headers))
+      )
   private def rosHeaderMapToRegularMap(
       headers: HeaderMap[String]): Map[String, IndexedSeq[String]] =
     headers.flatMap(m => Map(m._1.toLowerCase -> IndexedSeq(m._2)))

--- a/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
+++ b/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
@@ -17,8 +17,8 @@
 package github4s
 
 import github4s.GithubResponses._
-import io.circe.Decoder
-import io.circe.parser._
+import io.circe._
+import io.circe.syntax._
 import scalaj.http._
 import cats.implicits._
 import github4s.free.interpreters.Capture
@@ -89,10 +89,12 @@ trait HttpRequestBuilderExtensionJVM {
     Either.right(GHResult((): Unit, r.code, toLowerCase(r.headers)))
 
   def decodeEntity[A](r: HttpResponse[String])(implicit D: Decoder[A]): GHResponse[A] =
-    decode[A](r.body).bimap(
-      e ⇒ JsonParsingException(e.getMessage, r.body),
-      result ⇒ GHResult(result, r.code, toLowerCase(r.headers))
-    )
+    r.body.asJson
+      .as[A]
+      .bimap(
+        e ⇒ JsonParsingException(e.getMessage, r.body),
+        result ⇒ GHResult(result, r.code, toLowerCase(r.headers))
+      )
 
   private def toLowerCase(
       headers: Map[String, IndexedSeq[String]]): Map[String, IndexedSeq[String]] =

--- a/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
+++ b/github4s/jvm/src/main/scala/github4s/HttpRequestBuilderExtensionJVM.scala
@@ -19,6 +19,7 @@ package github4s
 import github4s.GithubResponses._
 import io.circe._
 import io.circe.syntax._
+import io.circe.jackson._
 import scalaj.http._
 import cats.implicits._
 import github4s.free.interpreters.Capture
@@ -89,8 +90,8 @@ trait HttpRequestBuilderExtensionJVM {
     Either.right(GHResult((): Unit, r.code, toLowerCase(r.headers)))
 
   def decodeEntity[A](r: HttpResponse[String])(implicit D: Decoder[A]): GHResponse[A] =
-    r.body.asJson
-      .as[A]
+    parse(r.body)
+      .flatMap(_.as[A])
       .bimap(
         e ⇒ JsonParsingException(e.getMessage, r.body),
         result ⇒ GHResult(result, r.code, toLowerCase(r.headers))

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -69,10 +69,10 @@ object ProjectPlugin extends AutoPlugin {
         %%("simulacrum", V.simulacrum),
         %%("circe-core", V.circe),
         %%("circe-generic", V.circe),
-        %%("circe-parser", V.circe),
         %%("base64", V.base64),
-        %%("scalamockScalatest", V.scalamockScalatest) % "test",
-        %%("scalatest", V.scalaTest)                   % "test"
+        %%("circe-parser", V.circe)                    % Test,
+        %%("scalamockScalatest", V.scalamockScalatest) % Test,
+        %%("scalatest", V.scalaTest)                   % Test
       )
     )
 
@@ -83,7 +83,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val jvmDeps = Seq(
       libraryDependencies ++= Seq(
         %%("scalaj", V.scalaj),
-        "org.mock-server" % "mockserver-netty" % "3.10.4" % "test" excludeAll ExclusionRule(
+        "org.mock-server" % "mockserver-netty" % "3.10.4" % Test excludeAll ExclusionRule(
           "com.twitter")
       )
     )
@@ -100,7 +100,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val catsEffectDependencies = Seq(
       libraryDependencies ++= Seq(
         %%("cats-effect", V.catsEffect),
-        %%("scalatest", V.scalaTest) % "test"
+        %%("scalatest", V.scalaTest) % Test
       )
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -69,6 +69,7 @@ object ProjectPlugin extends AutoPlugin {
         %%("simulacrum", V.simulacrum),
         %%("circe-core", V.circe),
         %%("circe-generic", V.circe),
+        "io.circe" %% "circe-jackson28" % V.circe,
         %%("base64", V.base64),
         %%("circe-parser", V.circe)                    % Test,
         %%("scalamockScalatest", V.scalamockScalatest) % Test,


### PR DESCRIPTION
This PR replaces the **Jawn** parser by the **Jackson** parser, mainly in order to mitigate the binary issues that other libraries are experiencing because `circe-parser` is provided transitively:

* https://github.com/circe/circe/issues/823
* https://github.com/47deg/sbt-org-policies/issues/655#issuecomment-339140699
* https://github.com/lihaoyi/Ammonite/issues/718