### PR TITLE
Make the integration tests skippable

### DIFF
--- a/github4s/jvm/src/test/scala/github4s/unit/ApiSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/unit/ApiSpec.scala
@@ -24,6 +24,7 @@ import cats.implicits._
 import scalaj.http._
 import cats.Id
 import github4s.jvm.ImplicitsJVM
+import github4s.utils.Integration
 
 class ApiSpec
     extends FlatSpec
@@ -331,7 +332,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Repos >> CreateRelease" should "return the created release" in {
+  "Repos >> CreateRelease" should "return the created release" taggedAs Integration in {
     val response =
       repos.createRelease(
         accessToken,
@@ -360,7 +361,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Repos >> GetStatus" should "return the expected combined status when a valid ref is provided" in {
+  "Repos >> GetStatus" should "return the expected combined status when a valid ref is provided" taggedAs Integration in {
     val response =
       repos.getStatus(accessToken, headerUserAgent, validRepoOwner, validRepoName, validRefSingle)
     response should be('right)
@@ -380,7 +381,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Repos >> ListStatus" should "return the expected statuses when a valid ref is provided" in {
+  "Repos >> ListStatus" should "return the expected statuses when a valid ref is provided" taggedAs Integration in {
     val response = repos.listStatuses(
       accessToken,
       headerUserAgent,
@@ -410,7 +411,7 @@ class ApiSpec
     }
   }
 
-  "Repos >> CreateStatus" should "return the created status if a valid sha is provided" in {
+  "Repos >> CreateStatus" should "return the created status if a valid sha is provided" taggedAs Integration in {
     val response = repos.createStatus(
       accessToken,
       headerUserAgent,
@@ -467,7 +468,7 @@ class ApiSpec
     val response = users.get(accessToken, headerUserAgent, invalidUsername)
     response should be('left)
   }
-  "Users >> GetAuth" should "return the expected login for a valid accessToken" in {
+  "Users >> GetAuth" should "return the expected login for a valid accessToken" taggedAs Integration in {
     val response = users.getAuth(accessToken, headerUserAgent)
     response should be('right)
 
@@ -501,7 +502,7 @@ class ApiSpec
     }
   }
 
-  "Gists >> PostGist" should "return the provided gist for a valid request" in {
+  "Gists >> PostGist" should "return the provided gist for a valid request" taggedAs Integration in {
     val response =
       gists.newGist(
         validGistDescription,
@@ -516,7 +517,7 @@ class ApiSpec
     }
   }
 
-  "Gists >> GetGist" should "return the single gist for a valid request" in {
+  "Gists >> GetGist" should "return the single gist for a valid request" taggedAs Integration in {
     val response =
       gists.getGist(validGistId, sha = None, headerUserAgent, accessToken)
     response should be('right)
@@ -526,7 +527,7 @@ class ApiSpec
     }
   }
 
-  it should "return the specific revision of gist for a valid request" in {
+  it should "return the specific revision of gist for a valid request" taggedAs Integration in {
     val response =
       gists.getGist(validGistId, sha = Some(validGistSha), headerUserAgent, accessToken)
     response should be('right)
@@ -536,7 +537,7 @@ class ApiSpec
     }
   }
 
-  "Gists >> EditGist" should "return the provided gist for a valid request" in {
+  "Gists >> EditGist" should "return the provided gist for a valid request" taggedAs Integration in {
     val response =
       gists.editGist(
         validGistId,
@@ -586,7 +587,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "GitData >> CreateReference" should "return the single reference" in {
+  "GitData >> CreateReference" should "return the single reference" taggedAs Integration in {
     val response =
       gitData.createReference(
         accessToken,
@@ -613,7 +614,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "GitData >> UpdateReference" should "return the single reference" in {
+  "GitData >> UpdateReference" should "return the single reference" taggedAs Integration in {
     val response =
       gitData.updateReference(
         accessToken,
@@ -655,7 +656,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "GitData >> CreateCommit" should "return the single commit" in {
+  "GitData >> CreateCommit" should "return the single commit" taggedAs Integration in {
     val response =
       gitData.createCommit(
         accessToken,
@@ -684,7 +685,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "GitData >> CreateBlob" should "return the created blob" in {
+  "GitData >> CreateBlob" should "return the created blob" taggedAs Integration in {
     val response =
       gitData.createBlob(accessToken, headerUserAgent, validRepoOwner, validRepoName, validNote)
     response should be('right)
@@ -699,7 +700,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "GitData >> CreateTree" should "return the created tree" in {
+  "GitData >> CreateTree" should "return the created tree" taggedAs Integration in {
     val response =
       gitData.createTree(
         accessToken,
@@ -836,7 +837,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "PullRequests >> List PullRequestReviews" should "return a list of reviews when valid data is provided" in {
+  "PullRequests >> List PullRequestReviews" should "return a list of reviews when valid data is provided" taggedAs Integration in {
     val response = pullRequests.listReviews(
       accessToken,
       headerUserAgent,
@@ -855,7 +856,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "PullRequests >> Get PullRequestReview" should "return a single review when valid data is provided" in {
+  "PullRequests >> Get PullRequestReview" should "return a single review when valid data is provided" taggedAs Integration in {
     val response = pullRequests.getReview(
       accessToken,
       headerUserAgent,
@@ -876,7 +877,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> List" should "return the expected issues when a valid owner/repo is provided" in {
+  "Issues >> List" should "return the expected issues when a valid owner/repo is provided" taggedAs Integration in {
     val response =
       issues.list(accessToken, headerUserAgent, validRepoOwner, validRepoName)
     response should be('right)
@@ -897,7 +898,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> Get" should "return the expected issue when a valid owner/repo is provided" in {
+  "Issues >> Get" should "return the expected issue when a valid owner/repo is provided" taggedAs Integration in {
     val response =
       issues.get(accessToken, headerUserAgent, validRepoOwner, validRepoName, validIssueNumber)
     response should be('right)
@@ -906,7 +907,7 @@ class ApiSpec
       r.statusCode shouldBe okStatusCode
     }
   }
-  it should "return an issue which is just a Pull Request" in {
+  it should "return an issue which is just a Pull Request" taggedAs Integration in {
     val response =
       issues.get(
         accessToken,
@@ -927,7 +928,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> Create" should "return the created issue if valid data is provided" in {
+  "Issues >> Create" should "return the created issue if valid data is provided" taggedAs Integration in {
     val response = issues.create(
       accessToken,
       headerUserAgent,
@@ -971,7 +972,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> Edit" should "return the edited issue if valid data is provided" in {
+  "Issues >> Edit" should "return the edited issue if valid data is provided" taggedAs Integration in {
     val response = issues.edit(
       accessToken,
       headerUserAgent,
@@ -1021,7 +1022,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> Search" should "return the search result if valid data is provided" in {
+  "Issues >> Search" should "return the search result if valid data is provided" taggedAs Integration in {
     val response = issues.search(accessToken, headerUserAgent, validSearchQuery, List.empty)
     response should be('right)
 
@@ -1029,7 +1030,7 @@ class ApiSpec
       r.statusCode shouldBe okStatusCode
     }
   }
-  it should "return an empty result if a search query matching nothing is provided" in {
+  it should "return an empty result if a search query matching nothing is provided" taggedAs Integration in {
     val response =
       issues.search(accessToken, headerUserAgent, nonExistentSearchQuery, List.empty)
     response should be('right)
@@ -1040,7 +1041,7 @@ class ApiSpec
     }
   }
 
-  "Issues >> ListComments" should "return the expected issue comments when a valid issue number is provided" in {
+  "Issues >> ListComments" should "return the expected issue comments when a valid issue number is provided" taggedAs Integration in {
     val response =
       issues.listComments(
         accessToken,
@@ -1071,7 +1072,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> Create a Comment" should "return the comment created when a valid issue number is provided" in {
+  "Issues >> Create a Comment" should "return the comment created when a valid issue number is provided" taggedAs Integration in {
     val response =
       issues.createComment(
         accessToken,
@@ -1105,7 +1106,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> Edit a Comment" should "return the edited comment when a valid comment id is provided" in {
+  "Issues >> Edit a Comment" should "return the edited comment when a valid comment id is provided" taggedAs Integration in {
     val response =
       issues.editComment(
         accessToken,
@@ -1139,7 +1140,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> Delete a Comment" should "return deleted status when a valid comment id is provided" in {
+  "Issues >> Delete a Comment" should "return deleted status when a valid comment id is provided" taggedAs Integration in {
     val response =
       issues.deleteComment(
         accessToken,
@@ -1165,7 +1166,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> ListLabels" should "return the expected issue labels when a valid issue number is provided" in {
+  "Issues >> ListLabels" should "return the expected issue labels when a valid issue number is provided" taggedAs Integration in {
     val response =
       issues.listLabels(
         accessToken,
@@ -1196,7 +1197,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> RemoveLabel" should "return the removed issue labels when a valid issue number is provided" in {
+  "Issues >> RemoveLabel" should "return the removed issue labels when a valid issue number is provided" taggedAs Integration in {
     val response =
       issues.removeLabel(
         accessToken,
@@ -1235,7 +1236,7 @@ class ApiSpec
     response should be('left)
   }
 
-  "Issues >> AddLabels" should "return the assigned issue labels when a valid issue number is provided" in {
+  "Issues >> AddLabels" should "return the assigned issue labels when a valid issue number is provided" taggedAs Integration in {
     val response =
       issues.addLabels(
         accessToken,
@@ -1325,7 +1326,7 @@ class ApiSpec
     }
   }
 
-  "Activities >> Set a Thread Subscription" should "return the subscription when a valid thread id is provided" in {
+  "Activities >> Set a Thread Subscription" should "return the subscription when a valid thread id is provided" taggedAs Integration in {
     val response =
       activities.setThreadSub(accessToken, headerUserAgent, validThreadId, true, false)
     response should be('right)

--- a/github4s/shared/src/test/scala/github4s/integration/GHActivitiesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHActivitiesSpec.scala
@@ -20,11 +20,11 @@ import github4s.Github
 import github4s.Github._
 import github4s.free.domain.{Stargazer, StarredRepository, Subscription}
 import github4s.implicits._
-import github4s.utils.BaseIntegrationSpec
+import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHActivitiesSpec[T] extends BaseIntegrationSpec[T] {
 
-  "Activity >> Set a thread subscription" should "return expected response when a valid thread id is provided" in {
+  "Activity >> Set a thread subscription" should "return expected response when a valid thread id is provided" taggedAs Integration in {
     val response =
       Github(accessToken).activities
         .setThreadSub(validThreadId, true, false)
@@ -35,7 +35,7 @@ trait GHActivitiesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid thread id is passed" in {
+  it should "return error when an invalid thread id is passed" taggedAs Integration in {
     val response =
       Github(accessToken).activities
         .setThreadSub(invalidThreadId, true, false)
@@ -44,8 +44,7 @@ trait GHActivitiesSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-
-  "Activity >> ListStargazers" should "return the expected list of starrers for valid data" in {
+  "Activity >> ListStargazers" should "return the expected list of starrers for valid data" taggedAs Integration in {
     val response =
       Github(accessToken).activities
         .listStargazers(validRepoOwner, validRepoName, false)
@@ -58,7 +57,7 @@ trait GHActivitiesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return the expected list of starrers for valid data with dates if timeline" in {
+  it should "return the expected list of starrers for valid data with dates if timeline" taggedAs Integration in {
     val response =
       Github(accessToken).activities
         .listStargazers(validRepoOwner, validRepoName, true)
@@ -80,7 +79,7 @@ trait GHActivitiesSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Activity >> ListStarredRepositories" should "return the expected list of starred repos" in {
+  "Activity >> ListStarredRepositories" should "return the expected list of starred repos" taggedAs Integration in {
     val response =
       Github(accessToken).activities
         .listStarredRepositories(validUsername, false)
@@ -93,7 +92,7 @@ trait GHActivitiesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return the expected list of starred repos with dates if timeline" in {
+  it should "return the expected list of starred repos with dates if timeline" taggedAs Integration in {
     val response =
       Github(accessToken).activities
         .listStarredRepositories(validUsername, true)
@@ -106,7 +105,7 @@ trait GHActivitiesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error for invalid username" in {
+  it should "return error for invalid username" taggedAs Integration in {
     val response =
       Github(accessToken).activities
         .listStarredRepositories(invalidUsername, false)

--- a/github4s/shared/src/test/scala/github4s/integration/GHAuthSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHAuthSpec.scala
@@ -20,11 +20,11 @@ import github4s.Github
 import github4s.Github._
 import github4s.free.domain.Authorize
 import github4s.implicits._
-import github4s.utils.BaseIntegrationSpec
+import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHAuthSpec[T] extends BaseIntegrationSpec[T] {
 
-  "Auth >> NewAuth" should "return error on Left when invalid credential is provided" in {
+  "Auth >> NewAuth" should "return error on Left when invalid credential is provided" taggedAs Integration in {
 
     val response = Github().auth
       .newAuth(
@@ -39,7 +39,7 @@ trait GHAuthSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Auth >> AuthorizeUrl" should "return the expected URL for valid username" in {
+  "Auth >> AuthorizeUrl" should "return the expected URL for valid username" taggedAs Integration in {
     val response =
       Github().auth
         .authorizeUrl(validClientId, validRedirectUri, validScopes)
@@ -51,7 +51,7 @@ trait GHAuthSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  "Auth >> GetAccessToken" should "return error on Left for invalid code value" in {
+  "Auth >> GetAccessToken" should "return error on Left for invalid code value" taggedAs Integration in {
     val response = Github().auth
       .getAccessToken(validClientId, invalidClientSecret, "", validRedirectUri, "")
       .execFuture[T](headerUserAgent)

--- a/github4s/shared/src/test/scala/github4s/integration/GHGitDataSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHGitDataSpec.scala
@@ -21,11 +21,11 @@ import github4s.Github
 import github4s.Github._
 import github4s.free.domain.{Ref, RefCommit, TreeResult}
 import github4s.implicits._
-import github4s.utils.BaseIntegrationSpec
+import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHGitDataSpec[T] extends BaseIntegrationSpec[T] {
 
-  "GitData >> GetReference" should "return a list of references" in {
+  "GitData >> GetReference" should "return a list of references" taggedAs Integration in {
     val response = Github(accessToken).gitData
       .getReference(validRepoOwner, validRepoName, "heads")
       .execFuture[T](headerUserAgent)
@@ -36,7 +36,7 @@ trait GHGitDataSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return at least one reference" in {
+  it should "return at least one reference" taggedAs Integration in {
     val response = Github(accessToken).gitData
       .getReference(validRepoOwner, validRepoName, validRefSingle)
       .execFuture[T](headerUserAgent)
@@ -47,7 +47,7 @@ trait GHGitDataSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return an error when an invalid repository name is passed" in {
+  it should "return an error when an invalid repository name is passed" taggedAs Integration in {
     val response = Github(accessToken).gitData
       .getReference(validRepoOwner, invalidRepoName, validRefSingle)
       .execFuture[T](headerUserAgent)
@@ -55,7 +55,7 @@ trait GHGitDataSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "GitData >> GetCommit" should "return one commit" in {
+  "GitData >> GetCommit" should "return one commit" taggedAs Integration in {
     val response = Github(accessToken).gitData
       .getCommit(validRepoOwner, validRepoName, validCommitSha)
       .execFuture[T](headerUserAgent)
@@ -66,7 +66,7 @@ trait GHGitDataSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return an error when an invalid repository name is passed" in {
+  it should "return an error when an invalid repository name is passed" taggedAs Integration in {
     val response = Github(accessToken).gitData
       .getCommit(validRepoOwner, invalidRepoName, validCommitSha)
       .execFuture[T](headerUserAgent)
@@ -74,7 +74,7 @@ trait GHGitDataSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "GitData >> GetTree" should "return the file tree non-recursively" in {
+  "GitData >> GetTree" should "return the file tree non-recursively" taggedAs Integration in {
     val response =
       Github(accessToken).gitData
         .getTree(validRepoOwner, validRepoName, validCommitSha, recursive=false)
@@ -87,7 +87,7 @@ trait GHGitDataSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return the file tree recursively" in {
+  it should "return the file tree recursively" taggedAs Integration in {
     val response =
       Github(accessToken).gitData
         .getTree(validRepoOwner, validRepoName, validCommitSha, recursive=true)
@@ -99,7 +99,7 @@ trait GHGitDataSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return an error when an invalid repository name is passed" in {
+  it should "return an error when an invalid repository name is passed" taggedAs Integration in {
     val response = Github(accessToken).gitData
       .getTree(validRepoOwner, invalidRepoName, validCommitSha, recursive=false)
       .execFuture[T](headerUserAgent)

--- a/github4s/shared/src/test/scala/github4s/integration/GHIssuesSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHIssuesSpec.scala
@@ -20,11 +20,11 @@ import github4s.Github
 import github4s.Github._
 import github4s.free.domain.{Issue, Label, SearchIssuesResult, User}
 import github4s.implicits._
-import github4s.utils.BaseIntegrationSpec
+import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
 
-  "Issues >> List" should "return a list of issues" in {
+  "Issues >> List" should "return a list of issues" taggedAs Integration in {
     val response = Github(accessToken).issues
       .listIssues(validRepoOwner, validRepoName)
       .execFuture[T](headerUserAgent)
@@ -46,7 +46,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  "Issues >> Search" should "return at least one issue for a valid query" in {
+  "Issues >> Search" should "return at least one issue for a valid query" taggedAs Integration in {
     val response = Github(accessToken).issues
       .searchIssues(validSearchQuery, validSearchParams)
       .execFuture[T](headerUserAgent)
@@ -58,7 +58,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return an empty result for a non existent query string" in {
+  it should "return an empty result for a non existent query string" taggedAs Integration in {
     val response = Github(accessToken).issues
       .searchIssues(nonExistentSearchQuery, validSearchParams)
       .execFuture[T](headerUserAgent)
@@ -70,7 +70,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  "Issues >> Edit" should "edit the specified issue" in {
+  "Issues >> Edit" should "edit the specified issue" taggedAs Integration in {
     val response = Github(accessToken).issues
       .editIssue(
         validRepoOwner,
@@ -91,7 +91,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  "Issues >> ListLabels" should "return a list of labels" in {
+  "Issues >> ListLabels" should "return a list of labels" taggedAs Integration in {
     val response = Github(accessToken).issues
       .listLabels(validRepoOwner, validRepoName, validIssueNumber)
       .execFuture[T](headerUserAgent)
@@ -102,7 +102,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  "Issues >> RemoveLabel" should "return a list of removed labels" in {
+  "Issues >> RemoveLabel" should "return a list of removed labels" taggedAs Integration in {
     val response = Github(accessToken).issues
       .removeLabel(validRepoOwner, validRepoName, validIssueNumber, validIssueLabel.head)
       .execFuture[T](headerUserAgent)
@@ -113,7 +113,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  "Issues >> AddLabels" should "return a list of labels" in {
+  "Issues >> AddLabels" should "return a list of labels" taggedAs Integration in {
     val response = Github(accessToken).issues
       .addLabels(validRepoOwner, validRepoName, validIssueNumber, validIssueLabel)
       .execFuture[T](headerUserAgent)
@@ -124,7 +124,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  "GHIssues >> ListAvailableAssignees" should "return a list of users" in {
+  "GHIssues >> ListAvailableAssignees" should "return a list of users" taggedAs Integration in {
     val response = Github(accessToken).issues
       .listAvailableAssignees(validRepoOwner, validRepoName)
       .execFuture[T](headerUserAgent)
@@ -135,7 +135,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error for an invalid repo owner" in {
+  it should "return error for an invalid repo owner" taggedAs Integration in {
     val response = Github(accessToken).issues
       .listAvailableAssignees(invalidRepoOwner, validRepoName)
       .execFuture[T](headerUserAgent)
@@ -143,7 +143,7 @@ trait GHIssuesSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  it should "return error for an invalid repo name" in {
+  it should "return error for an invalid repo name" taggedAs Integration in {
     val response = Github(accessToken).issues
       .listAvailableAssignees(validRepoOwner, invalidRepoName)
       .execFuture[T](headerUserAgent)

--- a/github4s/shared/src/test/scala/github4s/integration/GHOrganizationsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHOrganizationsSpec.scala
@@ -20,11 +20,11 @@ import github4s.Github
 import github4s.Github._
 import github4s.free.domain.User
 import github4s.implicits._
-import github4s.utils.BaseIntegrationSpec
+import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHOrganizationsSpec[T] extends BaseIntegrationSpec[T] {
 
-  "Organization >> ListMembers" should "return the expected list of users" in {
+  "Organization >> ListMembers" should "return the expected list of users" taggedAs Integration in {
     val response =
       Github(accessToken).organizations
         .listMembers(validRepoOwner)
@@ -36,7 +36,7 @@ trait GHOrganizationsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error for an invalid org" in {
+  it should "return error for an invalid org" taggedAs Integration in {
     val response =
       Github(accessToken).organizations
         .listMembers(invalidUsername)
@@ -45,7 +45,7 @@ trait GHOrganizationsSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Organization >> ListOutsideCollaborators" should "return expected list of users" in {
+  "Organization >> ListOutsideCollaborators" should "return expected list of users" taggedAs Integration in {
     val response =
       Github(accessToken).organizations
       .listOutsideCollaborators(validOrganizationName)
@@ -57,7 +57,7 @@ trait GHOrganizationsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error for an invalid org" in {
+  it should "return error for an invalid org" taggedAs Integration in {
     val response =
       Github(accessToken).organizations
         .listOutsideCollaborators(invalidOrganizationName)

--- a/github4s/shared/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHPullRequestsSpec.scala
@@ -20,11 +20,11 @@ import github4s.Github
 import github4s.Github._
 import github4s.free.domain._
 import github4s.implicits._
-import github4s.utils.BaseIntegrationSpec
+import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
 
-  "PullRequests >> Get" should "return a right response when a valid pr number is provided" in {
+  "PullRequests >> Get" should "return a right response when a valid pr number is provided" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .get(validRepoOwner, validRepoName, validPullRequestNumber)
@@ -35,7 +35,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return an error when a valid issue number is provided" in {
+  it should "return an error when a valid issue number is provided" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .get(validRepoOwner, validRepoName, validIssueNumber)
@@ -44,7 +44,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  it should "return an error when an invalid repo name is passed" in {
+  it should "return an error when an invalid repo name is passed" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .get(validRepoOwner, invalidRepoName, validPullRequestNumber)
@@ -53,7 +53,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "PullRequests >> List" should "return a right response when valid repo is provided" in {
+  "PullRequests >> List" should "return a right response when valid repo is provided" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .list(validRepoOwner, validRepoName, pagination = Some(Pagination(1, 10)))
@@ -64,7 +64,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return a right response when a valid repo is provided but not all pull requests have body" in {
+  it should "return a right response when a valid repo is provided but not all pull requests have body" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .list("lloydmeta", "gh-test-repo", List(PRFilterOpen))
@@ -76,7 +76,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return a non empty list when valid repo and some filters are provided" in {
+  it should "return a non empty list when valid repo and some filters are provided" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .list(
@@ -91,7 +91,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid repo name is passed" in {
+  it should "return error when an invalid repo name is passed" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .list(validRepoOwner, invalidRepoName)
@@ -100,7 +100,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "PullRequests >> ListFiles" should "return a right response when a valid repo is provided" in {
+  "PullRequests >> ListFiles" should "return a right response when a valid repo is provided" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .listFiles(validRepoOwner, validRepoName, validPullRequestNumber)
@@ -112,7 +112,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return a right response when a valid repo is provided and not all files have 'patch'" in {
+  it should "return a right response when a valid repo is provided and not all files have 'patch'" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .listFiles("scala", "scala", 4877)
@@ -124,7 +124,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid repo name is passed" in {
+  it should "return error when an invalid repo name is passed" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .listFiles(validRepoOwner, invalidRepoName, validPullRequestNumber)
@@ -133,7 +133,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "PullRequests >> ListReviews" should "return a right response when a valid pr is provided" in {
+  "PullRequests >> ListReviews" should "return a right response when a valid pr is provided" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .listReviews(validRepoOwner, validRepoName, validPullRequestNumber)
@@ -145,7 +145,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid repo name is passed" in {
+  it should "return error when an invalid repo name is passed" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .listReviews(validRepoOwner, invalidRepoName, validPullRequestNumber)
@@ -154,7 +154,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "PullRequests >> GetReview" should "return a right response when a valid pr review is provided" in {
+  "PullRequests >> GetReview" should "return a right response when a valid pr review is provided" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .getReview(validRepoOwner, validRepoName, validPullRequestNumber, validPullRequestReviewNumber)
@@ -166,7 +166,7 @@ trait GHPullRequestsSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid repo name is passed" in {
+  it should "return error when an invalid repo name is passed" taggedAs Integration in {
     val response =
       Github(accessToken).pullRequests
         .getReview(validRepoOwner, invalidRepoName, validPullRequestNumber, validPullRequestReviewNumber)

--- a/github4s/shared/src/test/scala/github4s/integration/GHReposSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHReposSpec.scala
@@ -21,11 +21,11 @@ import github4s.Github
 import github4s.Github._
 import github4s.free.domain._
 import github4s.implicits._
-import github4s.utils.BaseIntegrationSpec
+import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
 
-  "Repos >> Get" should "return the expected name when a valid repo is provided" in {
+  "Repos >> Get" should "return the expected name when a valid repo is provided" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .get(validRepoOwner, validRepoName)
@@ -37,7 +37,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid repo name is passed" in {
+  it should "return error when an invalid repo name is passed" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .get(validRepoOwner, invalidRepoName)
@@ -46,7 +46,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Repos >> ListOrgRepos" should "return the expected repos when a valid org is provided" in {
+  "Repos >> ListOrgRepos" should "return the expected repos when a valid org is provided" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listOrgRepos(validRepoOwner)
@@ -58,7 +58,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid org is passed" in {
+  it should "return error when an invalid org is passed" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listOrgRepos(invalidRepoName)
@@ -67,7 +67,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Repos >> ListUserRepos" should "return the expected repos when a valid user is provided" in {
+  "Repos >> ListUserRepos" should "return the expected repos when a valid user is provided" taggedAs Integration in {
     val response = Github(accessToken).repos
       .listUserRepos(validUsername)
       .execFuture[T](headerUserAgent)
@@ -78,7 +78,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid user is passed" in {
+  it should "return error when an invalid user is passed" taggedAs Integration in {
     val response = Github(accessToken).repos
       .listUserRepos(invalidUsername)
       .execFuture[T](headerUserAgent)
@@ -86,7 +86,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Repos >> GetContents" should "return the expected contents when valid path is provided" in {
+  "Repos >> GetContents" should "return the expected contents when valid path is provided" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .getContents(validRepoOwner, validRepoName, validFilePath)
@@ -98,7 +98,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error when an invalid path is passed" in {
+  it should "return error when an invalid path is passed" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .getContents(validRepoOwner, validRepoName, invalidFilePath)
@@ -106,7 +106,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Repos >> ListCommits" should "return the expected list of commits for valid data" in {
+  "Repos >> ListCommits" should "return the expected list of commits for valid data" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listCommits(validRepoOwner, validRepoName)
@@ -118,7 +118,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error for invalid repo name" in {
+  it should "return error for invalid repo name" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listCommits(invalidRepoName, validRepoName)
@@ -127,7 +127,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Repos >> ListBranches" should "return the expected list of branches for valid data" in {
+  "Repos >> ListBranches" should "return the expected list of branches for valid data" taggedAs Integration in {
     val response =
       Github(accessToken).repos
       .listBranches(validRepoOwner, validRepoName)
@@ -139,7 +139,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error for invalid repo name" in {
+  it should "return error for invalid repo name" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listBranches(invalidRepoName, validRepoName)
@@ -148,7 +148,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Repos >> ListContributors" should "return the expected list of contributors for valid data" in {
+  "Repos >> ListContributors" should "return the expected list of contributors for valid data" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listContributors(validRepoOwner, validRepoName)
@@ -160,7 +160,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error for invalid repo name" in {
+  it should "return error for invalid repo name" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listContributors(invalidRepoName, validRepoName)
@@ -169,7 +169,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Repos >> ListCollaborators" should "return the expected list of collaborators for valid data" in {
+  "Repos >> ListCollaborators" should "return the expected list of collaborators for valid data" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listCollaborators(validRepoOwner, validRepoName)
@@ -181,7 +181,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error for invalid repo name" in {
+  it should "return error for invalid repo name" taggedAs Integration in {
     val response =
       Github(accessToken).repos
         .listCollaborators(invalidRepoName, validRepoName)
@@ -190,7 +190,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Repos >> GetStatus" should "return a combined status" in {
+  "Repos >> GetStatus" should "return a combined status" taggedAs Integration in {
     val response = Github(accessToken).repos
       .getCombinedStatus(validRepoOwner, validRepoName, validRefSingle)
       .execFuture[T](headerUserAgent)
@@ -201,14 +201,14 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return an error when an invalid ref is passed" in {
+  it should "return an error when an invalid ref is passed" taggedAs Integration in {
     val response = Github(accessToken).repos
       .getCombinedStatus(validRepoOwner, validRepoName, invalidRef)
       .execFuture[T](headerUserAgent)
     testFutureIsLeft(response)
   }
 
-  "Repos >> ListStatus" should "return a non empty list when a valid ref is provided" in {
+  "Repos >> ListStatus" should "return a non empty list when a valid ref is provided" taggedAs Integration in {
     val response = Github(accessToken).repos
       .listStatuses(validRepoOwner, validRepoName, validCommitSha)
       .execFuture[T](headerUserAgent)
@@ -219,7 +219,7 @@ trait GHReposSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return an error when an invalid ref is provided" in {
+  it should "return an error when an invalid ref is provided" taggedAs Integration in {
     val response = Github(accessToken).repos
       .listStatuses(validRepoOwner, validRepoName, invalidRef)
       .execFuture[T](headerUserAgent)

--- a/github4s/shared/src/test/scala/github4s/integration/GHUsersSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/integration/GHUsersSpec.scala
@@ -20,11 +20,11 @@ import github4s.Github
 import github4s.Github._
 import github4s.free.domain.User
 import github4s.implicits._
-import github4s.utils.BaseIntegrationSpec
+import github4s.utils.{BaseIntegrationSpec, Integration}
 
 trait GHUsersSpec[T] extends BaseIntegrationSpec[T] {
 
-  "Users >> Get" should "return the expected login for a valid username" in {
+  "Users >> Get" should "return the expected login for a valid username" taggedAs Integration in {
     val response =
       Github(accessToken).users.get(validUsername).execFuture[T](headerUserAgent)
 
@@ -34,7 +34,7 @@ trait GHUsersSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error on Left for invalid username" in {
+  it should "return error on Left for invalid username" taggedAs Integration in {
     val response = Github(accessToken).users
       .get(invalidUsername)
       .execFuture[T](headerUserAgent)
@@ -42,14 +42,14 @@ trait GHUsersSpec[T] extends BaseIntegrationSpec[T] {
     testFutureIsLeft(response)
   }
 
-  "Users >> GetAuth" should "return error on Left when no accessToken is provided" in {
+  "Users >> GetAuth" should "return error on Left when no accessToken is provided" taggedAs Integration in {
     val response =
       Github().users.getAuth.execFuture[T](headerUserAgent)
 
     testFutureIsLeft(response)
   }
 
-  "Users >> GetUsers" should "return users for a valid since value" in {
+  "Users >> GetUsers" should "return users for a valid since value" taggedAs Integration in {
     val response =
       Github(accessToken).users
         .getUsers(validSinceInt)
@@ -61,7 +61,7 @@ trait GHUsersSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return an empty list when a invalid since value is provided" in {
+  it should "return an empty list when a invalid since value is provided" taggedAs Integration in {
     val response =
       Github(accessToken).users
         .getUsers(invalidSinceInt)
@@ -73,7 +73,7 @@ trait GHUsersSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  "Users >> GetFollowing" should "return the expected following list for a valid username" in {
+  "Users >> GetFollowing" should "return the expected following list for a valid username" taggedAs Integration in {
     val response =
       Github(accessToken).users
         .getFollowing(validUsername)
@@ -85,13 +85,13 @@ trait GHUsersSpec[T] extends BaseIntegrationSpec[T] {
     })
   }
 
-  it should "return error on Left for invalid username" in {
+  it should "return error on Left for invalid username" taggedAs Integration in {
     val response =
       Github(accessToken).users
         .getFollowing(invalidUsername)
         .execFuture[T](headerUserAgent)
 
       testFutureIsLeft(response)
-  }  
+  }
 
 }

--- a/github4s/shared/src/test/scala/github4s/utils/BaseIntegrationSpec.scala
+++ b/github4s/shared/src/test/scala/github4s/utils/BaseIntegrationSpec.scala
@@ -20,12 +20,13 @@ import cats.syntax.either._
 import github4s.GithubResponses.{GHResponse, GHResult}
 import github4s.free.interpreters.{Capture, Interpreters}
 import github4s.HttpRequestBuilderExtension
-import org.scalatest.{Assertion, AsyncFlatSpec, Inspectors, Matchers}
+import org.scalatest.{Assertion, AsyncFlatSpec, Ignore, Inspectors, Matchers, Tag}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-abstract class BaseIntegrationSpec[T] extends AsyncFlatSpec with Matchers with Inspectors with TestData {
+object Integration extends Tag(if (sys.env.get("GITHUB4S_ACCESS_TOKEN").isDefined) "" else classOf[Ignore].getName)
 
+abstract class BaseIntegrationSpec[T] extends AsyncFlatSpec with Matchers with Inspectors with TestData {
   override implicit val executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
There are some unit tests in `ApiSpec` relying on the token being present so I ignored those as well

cc @SethTisue