### PR TITLE
Scala 2.13 release, drop Scala 2.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: scala
-
-dist: precise
+dist: xenial
 
 scala:
-- 2.11.12
-- 2.12.8
+- 2.12.9
+- 2.13.0
 
 env:
 - SCALAENV=jvm
@@ -14,12 +13,12 @@ env:
 
 matrix:
   exclude:
-  - scala: 2.11.12
+  - scala: 2.13.0
     env: G4SBUILD=docs
   - env: SCALAENV=all
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 before_install:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
@@ -74,7 +73,7 @@ jobs:
               sbt docs/publishMicrosite;
             fi
           fi
-      scala: 2.12.8
+      scala: 2.12.9
       env: SCALAENV=all
 
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,10 @@ pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
 
 lazy val root = (project in file("."))
-  .settings(moduleName := "github4s-root")
+  .settings(
+    moduleName := "github4s-root",
+    crossScalaVersions := Nil
+  )
   .aggregate(allModules: _*)
   .dependsOn(allModulesDeps: _*)
   .settings(noPublishSettings: _*)

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -29,7 +29,6 @@ object ProjectPlugin extends AutoPlugin {
       val paradise: String           = "2.1.1"
       val roshttp: String            = "2.2.4"
       val simulacrum: String         = "0.19.0"
-      val scala211: String           = "2.11.12"
       val scala212: String           = "2.12.9"
       val scala213: String           = "2.13.0"
       val scalaj: String             = "2.4.2"
@@ -126,7 +125,7 @@ object ProjectPlugin extends AutoPlugin {
       startYear := Option(2016),
       resolvers += Resolver.sonatypeRepo("snapshots"),
       scalaVersion := V.scala212,
-      crossScalaVersions := Seq(V.scala211, V.scala212, V.scala213),
+      crossScalaVersions := Seq(V.scala212, V.scala213),
       scalacOptions := {
         val withStripedLinter = scalacOptions.value filterNot Set("-Xlint").contains
         CrossVersion.partialVersion(scalaBinaryVersion.value) match {

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -24,7 +24,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val base64: String             = "0.2.9"
       val cats: String               = "2.0.0-RC1"
-      val catsEffect: String         = "1.3.1"
+      val catsEffect: String         = "2.0.0-RC1"
       val circe: String              = "0.12.0-RC1"
       val paradise: String           = "2.1.1"
       val roshttp: String            = "2.2.4"
@@ -32,7 +32,7 @@ object ProjectPlugin extends AutoPlugin {
       val scala212: String           = "2.12.9"
       val scala213: String           = "2.13.0"
       val scalaj: String             = "2.4.2"
-      val scalamockScalatest: String = "3.6.0"
+      val scalamock: String          = "4.3.0"
       val scalaTest: String          = "3.0.8"
       val scalaz: String             = "7.2.28"
 
@@ -71,9 +71,9 @@ object ProjectPlugin extends AutoPlugin {
         %%("circe-generic", V.circe),
         "io.circe" %% "circe-jackson28" % V.circe,
         %%("base64", V.base64),
-        %%("circe-parser", V.circe)                    % Test,
-        %%("scalamockScalatest", V.scalamockScalatest) % Test,
-        %%("scalatest", V.scalaTest)                   % Test
+        %%("circe-parser", V.circe)   % Test,
+        %%("scalamock", V.scalamock)  % Test,
+        %%("scalatest", V.scalaTest)  % Test
       )
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -22,19 +22,20 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val base64: String             = "0.2.4"
-      val cats: String               = "1.5.0"
-      val catsEffect: String         = "1.1.0"
-      val circe: String              = "0.11.0"
+      val base64: String             = "0.2.9"
+      val cats: String               = "1.6.1"
+      val catsEffect: String         = "1.3.1"
+      val circe: String              = "0.11.1"
       val paradise: String           = "2.1.1"
-      val roshttp: String            = "2.2.3"
-      val simulacrum: String         = "0.14.0"
+      val roshttp: String            = "2.2.4"
+      val simulacrum: String         = "0.19.0"
       val scala211: String           = "2.11.12"
-      val scala212: String           = "2.12.8"
-      val scalaj: String             = "2.4.1"
+      val scala212: String           = "2.12.9"
+      val scala213: String           = "2.13.0"
+      val scalaj: String             = "2.4.2"
       val scalamockScalatest: String = "3.6.0"
-      val scalaTest: String          = "3.0.5"
-      val scalaz: String             = "7.2.27"
+      val scalaTest: String          = "3.0.8"
+      val scalaz: String             = "7.2.28"
 
     }
 
@@ -84,7 +85,7 @@ object ProjectPlugin extends AutoPlugin {
     lazy val jvmDeps = Seq(
       libraryDependencies ++= Seq(
         %%("scalaj", V.scalaj),
-        "org.mock-server" % "mockserver-netty" % "3.10.4" % Test excludeAll ExclusionRule(
+        "org.mock-server" % "mockserver-netty" % "3.10.8" % Test excludeAll ExclusionRule(
           "com.twitter")
       )
     )
@@ -122,7 +123,7 @@ object ProjectPlugin extends AutoPlugin {
       startYear := Option(2016),
       resolvers += Resolver.sonatypeRepo("snapshots"),
       scalaVersion := V.scala212,
-      crossScalaVersions := Seq(V.scala211, V.scala212),
+      crossScalaVersions := Seq(V.scala211, V.scala212, V.scala213),
       scalacOptions ~= (_ filterNot Set("-Xlint").contains),
       orgGithubTokenSetting := "GITHUB4S_ACCESS_TOKEN",
       resolvers += Resolver.bintrayRepo("hmil", "maven"),
@@ -136,7 +137,7 @@ object ProjectPlugin extends AutoPlugin {
         ScalaJSBadge.apply(_),
         GitHubIssuesBadge.apply(_)
       ),
-      orgSupportedScalaJSVersion := Some("0.6.21"),
+      orgSupportedScalaJSVersion := Some("0.6.28"),
       orgScriptTaskListSetting ++= List(
         (ScoverageKeys.coverageAggregate in Test).asRunnableItemFull,
         "docs/tut".asRunnableItem

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.9.0")
-addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.11.4-SNAPSHOT")
+addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.12.0-M1")
 addSbtPlugin("com.47deg"          % "sbt-microsites"           % "0.9.2")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.9.0")
-addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.9.4")
+addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.11.3")
+addSbtPlugin("com.47deg"          % "sbt-microsites"           % "0.9.2")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.9.0")
-addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.11.3")
+addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.11.4-SNAPSHOT")
 addSbtPlugin("com.47deg"          % "sbt-microsites"           % "0.9.2")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.9.0")
-addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.12.0-M1")
+addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.12.0-M2")
 addSbtPlugin("com.47deg"          % "sbt-microsites"           % "0.9.2")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.7.0")
+addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"            % "0.9.0")
 addSbtPlugin("com.47deg"          % "sbt-org-policies"         % "0.9.4")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.26")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")


### PR DESCRIPTION
Well, I've tried to cross-build github4s with Scala 2.13, and after tuning a bit SBT files and bumping dependencies, this is the current state:

- Macro paradise compiler plugin is no longer necessary for 2.13 (-Ymacro-annotations)
- We are missing the following dependencies (I'm going to open issues there asking about their expected roadmap to 2.13)
    - org.scalamock#scalamock-scalatest-support_2.13;3.6.0
    - fr.hmil#roshttp_sjs0.6_2.13;2.2.4
- Circe is dropping support for Scala 2.11 in 0.12 (and adding support for Scala 2.13), so we are forced to either drop Circe dependency or to drop Scala 2.11 support ourselves

I also bumped `sbt-org-policies` version to use `0.11.4`, with @juanpedromoreno changes to exclude `kind-projector` from default settings, which was producing version problems as well.