### PR TITLE
Tagged test as integration

### DIFF
--- a/github4s/jvm/src/test/scala/github4s/unit/ApiSpec.scala
+++ b/github4s/jvm/src/test/scala/github4s/unit/ApiSpec.scala
@@ -400,7 +400,7 @@ class ApiSpec
       repos.listStatuses(None, headerUserAgent, validRepoOwner, validRepoName, validRefSingle)
     response should be('left)
   }
-  it should "return an empty list when an invalid ref is passed" in {
+  it should "return an empty list when an invalid ref is passed" taggedAs Integration in {
     val response =
       repos.listStatuses(accessToken, headerUserAgent, validRepoOwner, validRepoName, invalidRef)
     response should be('right)


### PR DESCRIPTION
I found that setting the `GITHUB4S_ACCESS_TOKEN` allows the test to pass and not having it makes it fail, so I tagged the test as `Integration`

#300 